### PR TITLE
Fix Modbus template loading issue caused by misplaced unique ID check

### DIFF
--- a/custom_components/protocol_wizard/config_flow.py
+++ b/custom_components/protocol_wizard/config_flow.py
@@ -74,8 +74,7 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """First step: protocol selection."""
         available_protocols = ProtocolRegistry.available_protocols()
-        await self.async_set_unique_id(user_input[CONF_HOST].lower())
-        self._abort_if_unique_id_configured()
+
         if user_input is not None:
             self._protocol = user_input.get(CONF_PROTOCOL, CONF_PROTOCOL_MODBUS)
             
@@ -245,7 +244,12 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_STOPBITS: user_input[CONF_STOPBITS],
                     CONF_BYTESIZE: user_input[CONF_BYTESIZE],
                 }
-                
+
+                # Set unique ID for serial connection
+                unique_id = f"modbus_serial_{final_data[CONF_SERIAL_PORT]}_{final_data[CONF_SLAVE_ID]}"
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
+
                 await self._async_test_modbus_connection(final_data)
                 
                 # Create entry with template in options if selected
@@ -293,6 +297,11 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_PORT: user_input[CONF_PORT],
                     CONF_IP: user_input[CONF_IP],
                 }
+
+                # Set unique ID for IP connection
+                unique_id = f"modbus_ip_{final_data[CONF_HOST]}_{final_data[CONF_PORT]}_{final_data[CONF_SLAVE_ID]}"
+                await self.async_set_unique_id(unique_id)
+                self._abort_if_unique_id_configured()
 
                 await self._async_test_modbus_connection(final_data)
                 


### PR DESCRIPTION
The unique ID validation was incorrectly placed in async_step_user before checking if user_input exists, causing templates to fail. This commit:

- Removes the misplaced unique_id check from async_step_user (was accessing user_input[CONF_HOST] before user_input was validated)
- Adds proper unique ID handling in modbus_serial step using "modbus_serial_{port}_{slave_id}" format
- Adds proper unique ID handling in modbus_ip step using "modbus_ip_{host}_{port}_{slave_id}" format

This ensures templates work correctly and prevents duplicate device entries while avoiding crashes during initial setup.

Fixes: d805da5 (Update config_flow.py)