### PR TITLE
Fix entity platform discovery for multi-slave Modbus architecture

### DIFF
--- a/custom_components/protocol_wizard/entity_base.py
+++ b/custom_components/protocol_wizard/entity_base.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_PROTOCOL_MQTT,
     CONF_PROTOCOL_BACNET,
     CONF_PROTOCOL,
+    CONF_SLAVES,
 )
 from .protocols.base import BaseProtocolCoordinator
 
@@ -187,10 +188,40 @@ class BaseEntityManager(ABC):
     async def sync_entities(self) -> None:
         """Create, update, and remove entities based on current config."""
         config_key = self._get_entities_config_key()
-        current_configs = self.entry.options.get(config_key, [])
+
+        # For Modbus, check if we have the new CONF_SLAVES structure
+        protocol = self.entry.data.get(CONF_PROTOCOL, CONF_PROTOCOL_MODBUS)
+        if protocol == CONF_PROTOCOL_MODBUS:
+            slaves = self.entry.options.get(CONF_SLAVES, [])
+            if slaves:
+                # Multi-slave mode: get entities from coordinator's slave
+                # The coordinator has slave_id and slave_index attributes set
+                if hasattr(self.coordinator, 'slave_index'):
+                    slave_index = self.coordinator.slave_index
+                    if slave_index < len(slaves):
+                        current_configs = slaves[slave_index].get('registers', [])
+                        _LOGGER.debug("Reading entities from slave %d (index %d): %d entities",
+                                     self.coordinator.slave_id, slave_index, len(current_configs))
+                    else:
+                        _LOGGER.warning("Slave index %d out of range (total slaves: %d)",
+                                       slave_index, len(slaves))
+                        current_configs = []
+                else:
+                    # Single slave mode (backward compatibility)
+                    current_configs = slaves[0].get('registers', [])
+                    _LOGGER.debug("Reading entities from single slave: %d entities", len(current_configs))
+            else:
+                # Old structure fallback
+                current_configs = self.entry.options.get(config_key, [])
+                _LOGGER.debug("Reading entities from old structure (%s): %d entities",
+                             config_key, len(current_configs))
+        else:
+            # Non-Modbus protocols use the config key directly
+            current_configs = self.entry.options.get(config_key, [])
+
         desired_ids = set()
         new_entities: list[Entity] = []
-        
+
         for config in current_configs:
             if not self._should_create_entity(config):
                 continue


### PR DESCRIPTION
Problem:
After template loading, coordinator showed 8 entities loaded but platforms created 0 entities (sensor sync: active=0, defined=0).

Root cause:
- Coordinator reads entities from: CONF_SLAVES[slave_index]['registers'] ✓
- Entity platforms read from: entry.options.get(CONF_REGISTERS, []) ✗

After migration, entities are moved to CONF_SLAVES structure but platforms still looked in CONF_REGISTERS (empty after migration).

Solution:
Updated sync_entities() in entity_base.py to:
1. Check if protocol is Modbus
2. Check if CONF_SLAVES structure exists
3. Read entities from slaves[coordinator.slave_index]['registers']
4. Fall back to old CONF_REGISTERS structure for backward compatibility

This ensures entity platforms can discover entities correctly in both:
- New multi-slave architecture (CONF_SLAVES)
- Legacy single-slave setup (CONF_REGISTERS)