### PR TITLE
Fix multi-slave menu not appearing for single slave devices

### DIFF
--- a/custom_components/protocol_wizard/options_flow.py
+++ b/custom_components/protocol_wizard/options_flow.py
@@ -103,19 +103,24 @@ class ProtocolWizardOptionsFlow(config_entries.OptionsFlow):
         menu_options = {
             "settings": "Settings",
         }
-        
-        # For Modbus with multiple slaves, show slave selection
+
+        # For Modbus with slaves structure, show slave selection
         if self.protocol == CONF_PROTOCOL_MODBUS:
             slaves = self._config_entry.options.get(CONF_SLAVES, [])
-            if slaves and len(slaves) > 1:
-                # Multi-slave mode
-                menu_options["select_slave"] = f"⚙️ Configure Slave ({len(slaves)} slaves)"
-            elif slaves and len(slaves) == 1:
-                # Single slave - show entity options directly (entities already loaded)
-                menu_options["add_entity"] = "Add entity"
-                if self._entities:
-                    menu_options["list_entities"] = f"Entities ({len(self._entities)})"
-                    menu_options["edit_entity"] = "Edit entity"
+            if slaves:
+                # Show slave management menu (allows adding more slaves)
+                slave_count = len(slaves)
+                if slave_count == 1:
+                    menu_options["select_slave"] = f"⚙️ Manage Slaves (1 slave, add more)"
+                else:
+                    menu_options["select_slave"] = f"⚙️ Manage Slaves ({slave_count} slaves)"
+
+                # If single slave, also show entity shortcuts for convenience
+                if slave_count == 1:
+                    menu_options["add_entity"] = "Add entity (quick)"
+                    if self._entities:
+                        menu_options["list_entities"] = f"Entities ({len(self._entities)})"
+                        menu_options["edit_entity"] = "Edit entity (quick)"
             else:
                 # No slaves - backward compat mode
                 menu_options["add_entity"] = "Add entity"
@@ -128,7 +133,7 @@ class ProtocolWizardOptionsFlow(config_entries.OptionsFlow):
             if self._entities:
                 menu_options["list_entities"] = f"Entities ({len(self._entities)})"
                 menu_options["edit_entity"] = "Edit entity"
-        
+
         # Template options (always available)
         menu_options.update({
             "load_template": "Load template",


### PR DESCRIPTION
Problem:
After creating first Modbus device, the "Manage Slaves" menu option only appeared when len(slaves) > 1. This meant users with a single slave device had no way to add additional slave devices to the same connection.

Root cause:
In async_step_init(), the logic was:
- len(slaves) > 1: show "select_slave" menu ✓
- len(slaves) == 1: show entity management only, NO slave menu ✗
- No slaves: backward compat mode

Solution:
Changed logic to always show "Manage Slaves" menu when slaves structure exists:
- len(slaves) >= 1: show "Manage Slaves" menu (allows adding more)
- len(slaves) == 1: also show entity shortcuts for convenience ("Add entity (quick)")
- Label shows "(1 slave, add more)" to hint that more can be added

This allows users to:
1. Add multiple slave devices to one Modbus connection
2. Configure each slave's entities independently
3. Still have quick shortcuts for single-slave setups