### PR TITLE
Fix duplicate device creation when adding multiple slaves

### DIFF
--- a/custom_components/protocol_wizard/__init__.py
+++ b/custom_components/protocol_wizard/__init__.py
@@ -218,7 +218,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 # IMPORTANT: Store slave_id in coordinator so it knows which entities to read
                 coordinator.slave_id = slave_id
                 coordinator.slave_index = idx  # Index in slaves list
-                
+
                 # Load template for this specific slave if specified
                 slave_template = slave_info.get("template")
                 if slave_template and not slave_info.get("template_applied"):
@@ -236,14 +236,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         hass.config_entries.async_update_entry(entry, options=options)
                 
                 await coordinator.async_config_entry_first_refresh()
-                
-                # Store with unique key if multiple slaves, otherwise use entry_id for backward compatibility
-                if len(slaves) > 1:
-                    coordinator_key = f"{entry.entry_id}_slave_{slave_id}"
-                else:
-                    coordinator_key = entry.entry_id
-                
+
+                # IMPORTANT: Always use consistent coordinator_key format
+                # This prevents duplicate devices when adding/removing slaves
+                coordinator_key = f"{entry.entry_id}_slave_{slave_id}"
+
+                # Store coordinator_key in coordinator for device identification
+                coordinator.coordinator_key = coordinator_key
+
                 hass.data[DOMAIN]["coordinators"][coordinator_key] = coordinator
+
+                # BACKWARD COMPAT: Also store first slave with entry.entry_id for platform access
+                if idx == 0:
+                    hass.data[DOMAIN]["coordinators"][entry.entry_id] = coordinator
+
                 coordinators_created.append((coordinator_key, slave_name, slave_id))
             
             # Create device registry entries for each slave

--- a/custom_components/protocol_wizard/number.py
+++ b/custom_components/protocol_wizard/number.py
@@ -55,9 +55,12 @@ async def async_setup_entry(
 ):
     """Set up number entities for any protocol."""
     coordinator = hass.data[DOMAIN]["coordinators"][entry.entry_id]
-    
+
+    # Use coordinator_key if available (multi-slave), otherwise use entry.entry_id
+    device_identifier = getattr(coordinator, 'coordinator_key', entry.entry_id)
+
     device_info = DeviceInfo(
-        identifiers={(DOMAIN, entry.entry_id)},
+        identifiers={(DOMAIN, device_identifier)},
         name=entry.title or f"{coordinator.protocol_name.title()} Device",
         manufacturer=coordinator.protocol_name.title(),
         model="Protocol Wizard",

--- a/custom_components/protocol_wizard/select.py
+++ b/custom_components/protocol_wizard/select.py
@@ -44,9 +44,12 @@ async def async_setup_entry(
 ):
     """Set up select entities for any protocol."""
     coordinator = hass.data[DOMAIN]["coordinators"][entry.entry_id]
-    
+
+    # Use coordinator_key if available (multi-slave), otherwise use entry.entry_id
+    device_identifier = getattr(coordinator, 'coordinator_key', entry.entry_id)
+
     device_info = DeviceInfo(
-        identifiers={(DOMAIN, entry.entry_id)},
+        identifiers={(DOMAIN, device_identifier)},
         name=entry.title or f"{coordinator.protocol_name.title()} Device",
         manufacturer=coordinator.protocol_name.title(),
         model="Protocol Wizard",

--- a/custom_components/protocol_wizard/sensor.py
+++ b/custom_components/protocol_wizard/sensor.py
@@ -48,9 +48,12 @@ async def async_setup_entry(
 ):
     """Set up sensor entities for any protocol."""
     coordinator = hass.data[DOMAIN]["coordinators"][entry.entry_id]
-    
+
+    # Use coordinator_key if available (multi-slave), otherwise use entry.entry_id
+    device_identifier = getattr(coordinator, 'coordinator_key', entry.entry_id)
+
     device_info = DeviceInfo(
-        identifiers={(DOMAIN, entry.entry_id)},
+        identifiers={(DOMAIN, device_identifier)},
         name=entry.title or f"{coordinator.protocol_name.title()} Device",
         manufacturer=coordinator.protocol_name.title(),
         model="Protocol Wizard",

--- a/custom_components/protocol_wizard/switch.py
+++ b/custom_components/protocol_wizard/switch.py
@@ -49,8 +49,11 @@ async def async_setup_entry(
     """Set up switch entities."""
     coordinator = hass.data[DOMAIN]["coordinators"][entry.entry_id]
 
+    # Use coordinator_key if available (multi-slave), otherwise use entry.entry_id
+    device_identifier = getattr(coordinator, 'coordinator_key', entry.entry_id)
+
     device_info = DeviceInfo(
-        identifiers={(DOMAIN, entry.entry_id)},
+        identifiers={(DOMAIN, device_identifier)},
         name=entry.title or f"{coordinator.protocol_name.title()} Device",
         manufacturer=coordinator.protocol_name.title(),
         model="Protocol Wizard",


### PR DESCRIPTION
Problem:
When adding a second slave device, Home Assistant showed 3 devices instead of 2:
1. "Modbus Hub" - original device with 17 entities
2. "Modbus Hub - Modbus Hub" - duplicate with 0 entities (orphaned)
3. "Modbus Hub - Slave 11" - new slave device

Root cause:
The coordinator_key format changed based on number of slaves:
- 1 slave: coordinator_key = entry.entry_id
- 2+ slaves: coordinator_key = f"{entry.entry_id}_slave_{slave_id}"

When adding the second slave, BOTH slaves got new device identifiers (entry_id_slave_1 and entry_id_slave_11), but the old device with identifier entry.entry_id remained orphaned in the device registry.

Solution:
1. __init__.py: Always use consistent coordinator_key format:
   - coordinator_key = f"{entry.entry_id}_slave_{slave_id}" (for ALL slaves)
   - Store coordinator_key in coordinator object for reference
   - Maintain backward compatibility by also storing first slave at entry.entry_id

2. Platform files (sensor, number, select, switch):
   - Use coordinator.coordinator_key for device identifier if available
   - Fall back to entry.entry_id for backward compatibility
   - Ensures entities attach to correct device

This ensures:
- No duplicate devices when adding/removing slaves
- Consistent device identification regardless of slave count
- Backward compatibility with existing single-slave setups
- Clean multi-slave architecture