### PR TITLE
Fix device registry cleanup when deleting Modbus slaves

### DIFF
--- a/custom_components/protocol_wizard/options_flow.py
+++ b/custom_components/protocol_wizard/options_flow.py
@@ -16,7 +16,7 @@ from .template_utils import (
     delete_template,
 )
 from homeassistant import config_entries
-from homeassistant.helpers import selector
+from homeassistant.helpers import selector, device_registry as dr
 #import asyncio
 from .const import (
     DOMAIN,
@@ -162,6 +162,16 @@ class ProtocolWizardOptionsFlow(config_entries.OptionsFlow):
                 slaves = list(self._config_entry.options.get(CONF_SLAVES, []))
                 if idx < len(slaves):
                     deleted = slaves.pop(idx)
+                    deleted_slave_id = deleted.get('slave_id')
+
+                    # Clean up device registry entry for this slave
+                    device_registry = dr.async_get(self.hass)
+                    coordinator_key = f"{self._config_entry.entry_id}_slave_{deleted_slave_id}"
+                    device = device_registry.async_get_device(identifiers={(DOMAIN, coordinator_key)})
+                    if device:
+                        device_registry.async_remove_device(device.id)
+                        _LOGGER.info("Removed device for slave %d from device registry", deleted_slave_id)
+
                     options = dict(self._config_entry.options)
                     options[CONF_SLAVES] = slaves
                     self.hass.config_entries.async_update_entry(self._config_entry, options=options)


### PR DESCRIPTION
Problem:
When deleting a slave device through the options menu, the slave was removed from the configuration and disappeared from the menu, but the device remained visible as an empty device in the Home Assistant device registry/overview.

Root cause:
The delete slave logic only:
1. Removed slave from options[CONF_SLAVES]
2. Reloaded the config entry

But it didn't remove the device registry entry for that slave, leaving an orphaned device with identifier "{entry_id}_slave_{slave_id}".

Solution:
In options_flow.py async_step_select_slave():
1. Import device_registry helper
2. Before reloading, look up the device by its identifier
3. Remove the device from device registry using async_remove_device()

This ensures:
- Clean removal of slave devices
- No orphaned devices in the overview
- Proper device lifecycle management