### PR TITLE
Add failsafe abort for BACnet and SNMP coordinators

### DIFF
--- a/custom_components/protocol_wizard/protocols/bacnet/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/bacnet/coordinator.py
@@ -262,46 +262,69 @@ class BACnetCoordinator(BaseProtocolCoordinator):
         if not entities:
             _LOGGER.warning("[BACnet] No entities configured for this device")
             return {}
-        
+
         new_data = {}
         failed_count = 0
-        
+        consecutive_failures = 0
+        max_consecutive_failures = 2
+        # Also limit total failures to prevent long update cycles
+        max_total_failures = min(5, max(2, len(entities) // 3))
+
         async with self._lock:
             for entity in entities:
+                # Early abort if device is clearly dead (consecutive failures)
+                if consecutive_failures >= max_consecutive_failures:
+                    _LOGGER.warning(
+                        "[BACnet] Too many consecutive failures (%d) — aborting update cycle",
+                        max_consecutive_failures
+                    )
+                    break
+
+                # Also abort if too many total failures (even if not consecutive)
+                if failed_count >= max_total_failures:
+                    _LOGGER.warning(
+                        "[BACnet] Too many total failures (%d/%d) — aborting update cycle",
+                        failed_count, len(entities)
+                    )
+                    break
+
                 try:
                     # Parse BACnet address: "analogInput:0:presentValue"
                     address = entity.get("address")
                     if not address:
                         _LOGGER.warning("Entity %s has no address", entity.get("name"))
                         continue
-                    
+
                     object_type, instance, property_name = parse_bacnet_address(address)
-                    
+
                     # Read property value
                     result = await self.client.read_property(
                         object_type,
                         instance,
                         property_name
                     )
-                    
+
                     if result is None:
                         failed_count += 1
+                        consecutive_failures += 1
                         _LOGGER.debug(
                             "Failed to read %s for entity %s",
                             address,
                             entity.get("name")
                         )
                         continue
-                    
+
+                    consecutive_failures = 0  # reset on success
+
                     # Generate entity key
                     key = entity_key(entity["name"])
-                    
+
                     # Decode and format value
                     decoded = self._decode_value(result, entity)
                     formatted = self._format_value(decoded, entity)
-                    
+
                     new_data[key] = formatted
-                    
+
                 except ValueError as err:
                     _LOGGER.error(
                         "Invalid address format for entity %s: %s",
@@ -309,7 +332,8 @@ class BACnetCoordinator(BaseProtocolCoordinator):
                         err
                     )
                     failed_count += 1
-                    
+                    consecutive_failures += 1
+
                 except Exception as err:
                     _LOGGER.error(
                         "Error reading entity %s: %s",
@@ -317,7 +341,8 @@ class BACnetCoordinator(BaseProtocolCoordinator):
                         err
                     )
                     failed_count += 1
-        
+                    consecutive_failures += 1
+
         # Log summary
         if failed_count > 0:
             _LOGGER.info(

--- a/custom_components/protocol_wizard/protocols/snmp/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/snmp/coordinator.py
@@ -54,9 +54,30 @@ class SNMPCoordinator(BaseProtocolCoordinator):
             return {}
 
         new_data = {}
+        failed_count = 0
+        consecutive_failures = 0
+        max_consecutive_failures = 2
+        # Also limit total failures to prevent long update cycles
+        max_total_failures = min(5, max(2, len(entities) // 3))
 
         async with self._lock:
             for entity in entities:
+                # Early abort if device is clearly dead (consecutive failures)
+                if consecutive_failures >= max_consecutive_failures:
+                    _LOGGER.warning(
+                        "[SNMP] Too many consecutive failures (%d) — aborting update cycle",
+                        max_consecutive_failures
+                    )
+                    break
+
+                # Also abort if too many total failures (even if not consecutive)
+                if failed_count >= max_total_failures:
+                    _LOGGER.warning(
+                        "[SNMP] Too many total failures (%d/%d) — aborting update cycle",
+                        failed_count, len(entities)
+                    )
+                    break
+
                 key = oid_key(entity["name"])
                 oid = entity["address"]
                 read_mode = entity.get("read_mode", "get")
@@ -68,7 +89,10 @@ class SNMPCoordinator(BaseProtocolCoordinator):
                         if not walk_results:
                             new_data[key] = "No results"
                             new_data[f"{key}_raw"] = []  # empty list
+                            failed_count += 1
+                            consecutive_failures += 1
                         else:
+                            consecutive_failures = 0  # reset on success
                             # Simple, straight OID = value dump
                             walk_lines = [
                                 f"{oid_str} = {value.prettyPrint() if hasattr(value, 'prettyPrint') else value}"
@@ -80,7 +104,10 @@ class SNMPCoordinator(BaseProtocolCoordinator):
                     else:
                         raw_value = await self.client.read(oid)
                         if raw_value is None:
+                            failed_count += 1
+                            consecutive_failures += 1
                             continue
+                        consecutive_failures = 0  # reset on success
                         # Decode / format
                         decoded = self._decode_value(raw_value, entity)
                         formatted = self._format_value(decoded, entity)
@@ -88,6 +115,12 @@ class SNMPCoordinator(BaseProtocolCoordinator):
 
                 except Exception as err:
                     _LOGGER.error("Error processing %s %s: %s", read_mode, oid, err)
+                    failed_count += 1
+                    consecutive_failures += 1
+
+        # Log summary if there were failures
+        if failed_count > 0:
+            _LOGGER.info("[SNMP] Update completed with %d/%d failures", failed_count, len(entities))
 
         return new_data
 


### PR DESCRIPTION
When a device is unresponsive, abort the update cycle early after:
- 2 consecutive failures (device is dead)
- Or too many total failures (1/3 of entities, min 2, max 5)

This prevents the integration from locking up on startup when devices are offline. Modbus already had this; now BACnet and SNMP match.

MQTT doesn't need this as it's event-driven (reads from cache).

https://claude.ai/code/session_0141XkQRjcng4RKLD4Yv5FAr