### PR TITLE
Fix ruff linting errors in test files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,7 @@
 from __future__ import annotations
 
 import sys
-from pathlib import Path
-from unittest.mock import MagicMock, AsyncMock, PropertyMock, patch
+from unittest.mock import MagicMock, AsyncMock
 
 import pytest
 

--- a/tests/test_entity_base.py
+++ b/tests/test_entity_base.py
@@ -1,8 +1,7 @@
 """Tests for entity_base module: helpers, managers, and entity types."""
 from __future__ import annotations
 
-import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
+from unittest.mock import MagicMock
 
 from custom_components.protocol_wizard.entity_base import (
     get_safe_number_defaults,

--- a/tests/test_modbus_coordinator.py
+++ b/tests/test_modbus_coordinator.py
@@ -1,8 +1,7 @@
 """Tests for Modbus coordinator decode/encode logic."""
 from __future__ import annotations
 
-import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from custom_components.protocol_wizard.protocols.modbus.coordinator import (
     ModbusCoordinator,

--- a/tests/test_mqtt_coordinator.py
+++ b/tests/test_mqtt_coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import json
-import pytest
 from unittest.mock import MagicMock
 
 from custom_components.protocol_wizard.protocols.mqtt.coordinator import (

--- a/tests/test_protocol_registry.py
+++ b/tests/test_protocol_registry.py
@@ -1,11 +1,8 @@
 """Tests for the protocol registry and base protocol abstractions."""
 from __future__ import annotations
 
-import pytest
 from custom_components.protocol_wizard.protocols import ProtocolRegistry
 from custom_components.protocol_wizard.protocols.base import (
-    BaseProtocolClient,
-    BaseProtocolCoordinator,
     _SafeFormatDict,
 )
 
@@ -87,12 +84,6 @@ class TestBaseProtocolCoordinatorFormatValue:
         from custom_components.protocol_wizard.protocols.modbus.coordinator import (
             ModbusCoordinator,
         )
-        from unittest.mock import MagicMock
-
-        client = MagicMock()
-        hass = MagicMock()
-        entry = MagicMock()
-        from datetime import timedelta
 
         coord = object.__new__(ModbusCoordinator)
         # Manually init only what _format_value needs

--- a/tests/test_snmp_coordinator.py
+++ b/tests/test_snmp_coordinator.py
@@ -1,7 +1,6 @@
 """Tests for SNMP coordinator decode/encode logic."""
 from __future__ import annotations
 
-import pytest
 from unittest.mock import MagicMock
 
 from custom_components.protocol_wizard.protocols.snmp.coordinator import (

--- a/tests/test_template_utils.py
+++ b/tests/test_template_utils.py
@@ -5,7 +5,6 @@ import json
 import os
 import tempfile
 import pytest
-from unittest.mock import MagicMock, AsyncMock, patch
 from pathlib import Path
 
 from custom_components.protocol_wizard.template_utils import (
@@ -158,7 +157,7 @@ class TestBuiltinTemplates:
         for path in self._get_template_files():
             with open(path, "r", encoding="utf-8") as f:
                 try:
-                    data = json.load(f)
+                    json.load(f)
                 except json.JSONDecodeError:
                     pytest.fail(f"Invalid JSON in template: {path}")
 


### PR DESCRIPTION
- Remove unused imports (pytest, Path, MagicMock, AsyncMock, patch, etc.)
- Remove unused local variables (client, hass, entry, data)

https://claude.ai/code/session_0141XkQRjcng4RKLD4Yv5FAr