### PR TITLE
Add switch_options keyword for switch entities from templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ When adding or editing a register, the following fields are available:
 | **unit**           | No       | -             | Unit of measurement (e.g., "V", "A", "W")                                                                        |
 | **scale**          | No       | `1.0`         | Multiplier applied after decoding (`value × scale + offset`)                                                     |
 | **offset**         | No       | `0.0`         | Additive offset after scaling                                                                                    |
-| **options**        | No       | -             | JSON mapping for select entity (e.g., `{"0": "Off", "1": "On"}`)                                                 |
+| **options**        | No       | -             | JSON mapping for select/dropdown entity (e.g., `{"0": "Off", "1": "Heat", "2": "Cool"}`)                         |
+| **switch_options** | No       | -             | Creates a switch instead of select for 2-state values (e.g., `{"on_value": "1", "off_value": "0"}`)              |
 | **byte_order**     | No       | `big`         | Byte order within each word (big/little)                                                                         |
 | **word_order**     | No       | `big`         | Order of the 16-bit words (big/little) for multi-register values                                                 |
 | **format**         | No       | -             | python formating for read values like {d}d {h}h {m}m for seconds to human readible value                         |
@@ -209,6 +210,10 @@ When adding or editing a register, the following fields are available:
 - **Voltages/Currents**: `data_type = "uint16"`, `scale = 0.1` or `0.01`, unit "V"/"A"
 - **Power**: Often `uint32` or `float32` with appropriate scaling
 - **Status bits**: Use `coil`/`discrete` + `options` JSON for friendly names
+- **On/Off toggle**: Use `switch_options` for a simple switch instead of a dropdown:
+  ```json
+  {"name": "Pump", "address": 100, "rw": "rw", "switch_options": {"on_value": "1", "off_value": "0"}}
+  ```
 
 ## Why Choose Protocol Wizard?
 

--- a/custom_components/protocol_wizard/entity_base.py
+++ b/custom_components/protocol_wizard/entity_base.py
@@ -499,7 +499,7 @@ class ProtocolWizardNumberBase(CoordinatorEntity, NumberEntity):
             _LOGGER.error("Failed to write value to %s", self._config.get("name"))
 
 class ProtocolWizardSwitchBase(CoordinatorEntity, SwitchEntity):
-    """Protocol-agnostic switch entity (for coils)."""
+    """Protocol-agnostic switch entity (for coils or switch_options)."""
 
     _attr_has_entity_name = True
     _attr_should_poll = False
@@ -519,31 +519,72 @@ class ProtocolWizardSwitchBase(CoordinatorEntity, SwitchEntity):
         self._attr_unique_id = unique_id
         self._attr_name = entity_config.get("name")
         self._attr_device_info = device_info
-        self._attr_icon = "mdi:toggle-switch" # can be overwritten if there is an icon requested by config
+        self._attr_icon = "mdi:toggle-switch"
         apply_common_entity_attributes(self, entity_config, hass=self.hass)
         set_readonly_protocol_settings(self, entity_config)
 
+        # Parse switch_options for value mapping
+        # Format: {"on_value": "1", "off_value": "0"} or {"on": "1", "off": "0"}
+        switch_opts = entity_config.get("switch_options", {})
+        if isinstance(switch_opts, str):
+            try:
+                switch_opts = json.loads(switch_opts)
+            except (json.JSONDecodeError, TypeError):
+                switch_opts = {}
+
+        # Support both "on_value"/"off_value" and "on"/"off" formats
+        self._on_value = switch_opts.get("on_value", switch_opts.get("on"))
+        self._off_value = switch_opts.get("off_value", switch_opts.get("off"))
+        self._use_switch_options = self._on_value is not None and self._off_value is not None
 
     @property
     def is_on(self) -> bool:
         """Return true if switch is on."""
         value = self.coordinator.data.get(self._key)
+        if self._use_switch_options:
+            return str(value) == str(self._on_value)
         return bool(value)
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
+        if self._use_switch_options:
+            write_value = self._on_value
+            # Try to preserve numeric type
+            try:
+                if "." in str(self._on_value):
+                    write_value = float(self._on_value)
+                else:
+                    write_value = int(self._on_value)
+            except (ValueError, TypeError):
+                pass
+        else:
+            write_value = True
+
         await self.coordinator.async_write_entity(
             address=str(self._config["address"]),
-            value=True,
+            value=write_value,
             entity_config=self._config,
         )
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
+        if self._use_switch_options:
+            write_value = self._off_value
+            # Try to preserve numeric type
+            try:
+                if "." in str(self._off_value):
+                    write_value = float(self._off_value)
+                else:
+                    write_value = int(self._off_value)
+            except (ValueError, TypeError):
+                pass
+        else:
+            write_value = False
+
         await self.coordinator.async_write_entity(
             address=str(self._config["address"]),
-            value=False,
+            value=write_value,
             entity_config=self._config,
         )
         await self.coordinator.async_request_refresh()

--- a/custom_components/protocol_wizard/select.py
+++ b/custom_components/protocol_wizard/select.py
@@ -19,6 +19,10 @@ class SelectManager(BaseEntityManager):
 
     def _should_create_entity(self, entity_config: dict) -> bool:
         """Create select for writable entities with options mapping."""
+        # If switch_options exists -> let switch handle it
+        if entity_config.get("switch_options"):
+            return False
+
         has_options = bool(entity_config.get("options"))
         is_writable = entity_config.get("rw") in ("rw", "write")
         return has_options and is_writable

--- a/custom_components/protocol_wizard/switch.py
+++ b/custom_components/protocol_wizard/switch.py
@@ -13,18 +13,24 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class SwitchManager(BaseEntityManager):
-    """Manages switch entities (coils)."""
+    """Manages switch entities (coils and switch_options)."""
 
     def _should_create_entity(self, entity_config: dict) -> bool:
-        """Create switch for writeable coils only."""
-        reg_type = entity_config.get("register_type", "holding").lower()
+        """Create switch for writeable coils or entities with switch_options."""
         rw = entity_config.get("rw", "read")
+        is_writable = rw in ("write", "rw")
 
-        # If options exist -> let select handle it
+        # If switch_options exists -> create switch with value mapping
+        if entity_config.get("switch_options") and is_writable:
+            return True
+
+        # If regular options exist -> let select handle it
         if entity_config.get("options"):
             return False
 
-        return reg_type == "coil" and rw in ("write", "rw")
+        # For coils without options
+        reg_type = entity_config.get("register_type", "holding").lower()
+        return reg_type == "coil" and is_writable
 
     def _create_entity(self, entity_config: dict, unique_id: str, key: str):
         return ProtocolWizardSwitchBase(


### PR DESCRIPTION
New template keyword `switch_options` creates a switch entity instead of a select dropdown for 2-state values.

Format: {"on_value": "1", "off_value": "0"} or {"on": "1", "off": "0"}

Example:
  {"name": "Pump", "address": 100, "rw": "rw", "switch_options": {"on_value": "1", "off_value": "0"}}

Changes:
- switch.py: Handle switch_options to create switches
- entity_base.py: ProtocolWizardSwitchBase parses on/off values
- select.py: Skip entities with switch_options (let switch handle them)
- README.md: Document new keyword

https://claude.ai/code/session_0141XkQRjcng4RKLD4Yv5FAr