### PR TITLE
Fix 160 ruff lint errors

### DIFF
--- a/custom_components/protocol_wizard/__init__.py
+++ b/custom_components/protocol_wizard/__init__.py
@@ -2,64 +2,70 @@
 #-- base init.py protocol wizard
 #------------------------------------------
 """The Protocol Wizard integration."""
-import shutil
+import asyncio
 import logging
 import os
-import asyncio
 import re
+import shutil
+from datetime import timedelta
 
-from homeassistant.helpers import device_registry as dr, entity_registry as er, config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient, AsyncModbusUdpClient
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.service import SupportsResponse
-from datetime import timedelta
-# Import protocol registry and plugins
-from .protocols import ProtocolRegistry
-from .protocols.modbus import ModbusClient
-from .protocols.snmp import SNMPClient
-from .protocols.mqtt import MQTTClient
-from .protocols.bacnet.client import BACnetClient
-from .template_utils import ensure_user_template_dirs, load_template
+from pymodbus.client import (
+    AsyncModbusSerialClient,
+    AsyncModbusTcpClient,
+    AsyncModbusUdpClient,
+)
 
 from .const import (
+    CONF_BACNET_DEVICES,
     CONF_BAUDRATE,
     CONF_BYTESIZE,
     CONF_CONNECTION_TYPE,
+    CONF_ENTITIES,
     CONF_HOST,
+    CONF_NAME,
     CONF_PARITY,
     CONF_PORT,
+    CONF_PROTOCOL,
+    CONF_PROTOCOL_BACNET,
+    CONF_PROTOCOL_MODBUS,
+    CONF_PROTOCOL_MQTT,
+    CONF_PROTOCOL_SNMP,
+    CONF_REGISTERS,
     CONF_SERIAL_PORT,
     CONF_SLAVE_ID,
+    CONF_SLAVES,
     CONF_STOPBITS,
+    CONF_TEMPLATE,
+    CONF_TEMPLATE_APPLIED,
     CONF_UPDATE_INTERVAL,
-    CONF_NAME,
-    CONNECTION_TYPE_SERIAL,
     CONNECTION_TYPE_IP,
-    CONNECTION_TYPE_UDP,
+    CONNECTION_TYPE_SERIAL,
     CONNECTION_TYPE_TCP,
+    CONNECTION_TYPE_UDP,
     DEFAULT_BAUDRATE,
     DEFAULT_BYTESIZE,
     DEFAULT_PARITY,
     DEFAULT_STOPBITS,
     DOMAIN,
-    CONF_PROTOCOL_MODBUS,
-    CONF_PROTOCOL_SNMP,
-    CONF_PROTOCOL_MQTT,
-    CONF_PROTOCOL_BACNET,
-    CONF_PROTOCOL,
-    CONF_TEMPLATE,
-    CONF_TEMPLATE_APPLIED,
-    CONF_ENTITIES,
-    CONF_REGISTERS,
-    CONF_SLAVES,
-    CONF_BACNET_DEVICES,
     SIGNAL_ENTITY_SYNC,
 )
 
+# Import protocol registry and plugins
+from .protocols import ProtocolRegistry
+from .protocols.bacnet.client import BACnetClient
+from .protocols.modbus import ModbusClient
+from .protocols.mqtt import MQTTClient
+from .protocols.snmp import SNMPClient
+from .template_utils import ensure_user_template_dirs, load_template
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -613,7 +619,13 @@ def _create_snmp_client(config: dict) -> SNMPClient:
 
 def _create_mqtt_client(config: dict) -> MQTTClient:
     """Create MQTT client (no caching needed - manages its own connection)."""
-    from .protocols.mqtt import MQTTClient, CONF_BROKER, CONF_USERNAME, CONF_PASSWORD, DEFAULT_PORT
+    from .protocols.mqtt import (
+        CONF_BROKER,
+        CONF_PASSWORD,
+        CONF_USERNAME,
+        DEFAULT_PORT,
+        MQTTClient,
+    )
 
     return MQTTClient(
         broker=config[CONF_BROKER],
@@ -804,7 +816,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
             # Add optional fields if provided
             for field in ["format", "options", "device_class", "state_class", "entity_category", "icon", "min", "max", "step"]:
-                if field in call.data and call.data[field]:
+                if call.data.get(field):
                     new_entity[field] = call.data[field]
 
             # Check for duplicates
@@ -869,7 +881,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
         except Exception as err:
             _LOGGER.error("Failed to add entity: %s", err, exc_info=True)
-            raise HomeAssistantError(f"Failed to add entity: {str(err)}") from err
+            raise HomeAssistantError(f"Failed to add entity: {err!s}") from err
 
     async def handle_write_register(call: ServiceCall):
         """Generic write service (protocol-agnostic) with detailed logging."""
@@ -901,7 +913,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
         except Exception as err:
             _LOGGER.error("Unexpected exception in write_register service for address %s: %s", address, err, exc_info=True)
-            raise HomeAssistantError(f"Write failed for address {address}: {str(err)}") from err
+            raise HomeAssistantError(f"Write failed for address {address}: {err!s}") from err
 
     async def handle_read_register(call: ServiceCall):
         """Generic read service (protocol-agnostic)."""

--- a/custom_components/protocol_wizard/config_flow.py
+++ b/custom_components/protocol_wizard/config_flow.py
@@ -1,53 +1,63 @@
 """Config flow for Protocol Wizard."""
+import asyncio
 import logging
 from typing import Any
+
 import serial.tools.list_ports
 import voluptuous as vol
-import asyncio
 from homeassistant import config_entries
-from homeassistant.helpers import selector
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
-from pymodbus.client import AsyncModbusSerialClient, AsyncModbusTcpClient, AsyncModbusUdpClient
-from .protocols.mqtt import CONF_BROKER, DEFAULT_PORT, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
+from pymodbus.client import (
+    AsyncModbusSerialClient,
+    AsyncModbusTcpClient,
+    AsyncModbusUdpClient,
+)
+
 from .const import (
-    CONNECTION_TYPE_SERIAL,
-    CONNECTION_TYPE_IP,
-    CONNECTION_TYPE_TCP,
-    CONNECTION_TYPE_UDP,
-    CONF_CONNECTION_TYPE,
-    CONF_HOST,
-    CONF_PORT,
-    CONF_SERIAL_PORT,
-    CONF_SLAVE_ID,
     CONF_BAUDRATE,
-    CONF_PARITY,
-    CONF_NAME,
-    CONF_STOPBITS,
     CONF_BYTESIZE,
+    CONF_CONNECTION_TYPE,
     CONF_FIRST_REG,
     CONF_FIRST_REG_SIZE,
-    CONF_UPDATE_INTERVAL,
-    CONF_SLAVES,
-    DEFAULT_SLAVE_ID,
-    DEFAULT_BAUDRATE,
-    DEFAULT_TCP_PORT,
-    DEFAULT_PARITY,
-    DEFAULT_STOPBITS,
-    DEFAULT_BYTESIZE,
-    DOMAIN,
-    CONF_PROTOCOL_MODBUS,
-    CONF_PROTOCOL_SNMP,
-    CONF_PROTOCOL_MQTT,
-    CONF_PROTOCOL_BACNET,
-    CONF_PROTOCOL,
+    CONF_HOST,
     CONF_IP,
+    CONF_NAME,
+    CONF_PARITY,
+    CONF_PORT,
+    CONF_PROTOCOL,
+    CONF_PROTOCOL_BACNET,
+    CONF_PROTOCOL_MODBUS,
+    CONF_PROTOCOL_MQTT,
+    CONF_PROTOCOL_SNMP,
+    CONF_SERIAL_PORT,
+    CONF_SLAVE_ID,
+    CONF_SLAVES,
+    CONF_STOPBITS,
     CONF_TEMPLATE,
+    CONF_UPDATE_INTERVAL,
+    CONNECTION_TYPE_IP,
+    CONNECTION_TYPE_SERIAL,
+    CONNECTION_TYPE_TCP,
+    CONNECTION_TYPE_UDP,
+    DEFAULT_BAUDRATE,
+    DEFAULT_BYTESIZE,
+    DEFAULT_PARITY,
+    DEFAULT_SLAVE_ID,
+    DEFAULT_STOPBITS,
+    DEFAULT_TCP_PORT,
+    DOMAIN,
 )
 from .options_flow import ProtocolWizardOptionsFlow
 from .protocols import ProtocolRegistry
-from .template_utils import get_available_templates, get_template_dropdown_choices, load_template
+from .protocols.mqtt import CONF_BROKER, CONF_PASSWORD, CONF_USERNAME, DEFAULT_PORT
+from .template_utils import (
+    get_available_templates,
+    get_template_dropdown_choices,
+    load_template,
+)
 
 _LOGGER = logging.getLogger(__name__)
 # Reduce noise from pymodbus

--- a/custom_components/protocol_wizard/entity_base.py
+++ b/custom_components/protocol_wizard/entity_base.py
@@ -5,30 +5,32 @@
 """Protocol-agnostic base entity classes."""
 from __future__ import annotations
 
-import logging
-from typing import Any
-from abc import ABC, abstractmethod
 import json
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.components.sensor import SensorEntity
-from homeassistant.components.number import NumberEntity,NumberMode
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.components.select import SelectEntity
-from homeassistant.helpers import entity_registry as er
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo, Entity, EntityCategory
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
 from .const import (
-    CONF_ENTITIES,
-    CONF_REGISTERS,
-    CONF_PROTOCOL_MODBUS,
-#    CONF_PROTOCOL_SNMP,
-    CONF_PROTOCOL_MQTT,
-    CONF_PROTOCOL_BACNET,
-    CONF_PROTOCOL,
-    CONF_SLAVES,
     CONF_BACNET_DEVICES,
+    CONF_ENTITIES,
+    CONF_PROTOCOL,
+    CONF_PROTOCOL_BACNET,
+    CONF_PROTOCOL_MODBUS,
+    #    CONF_PROTOCOL_SNMP,
+    CONF_PROTOCOL_MQTT,
+    CONF_REGISTERS,
+    CONF_SLAVES,
     SIGNAL_ENTITY_SYNC,
 )
 from .protocols.base import BaseProtocolCoordinator
@@ -179,17 +181,14 @@ class BaseEntityManager(ABC):
     @abstractmethod
     def _should_create_entity(self, entity_config: dict) -> bool:
         """Determine if entity should be created for this config."""
-        pass
     
     @abstractmethod
     def _create_entity(self, entity_config: dict, unique_id: str, key: str) -> Entity:
         """Create the appropriate entity type."""
-        pass
     
     @abstractmethod
     def _get_entity_type_suffix(self) -> str:
         """Get suffix for unique_id (e.g., 'sensor', 'number')."""
-        pass
     
     def _get_entities_config_key(self) -> str:
         """Get the config key for entities list. Override if protocol uses different key."""
@@ -482,7 +481,7 @@ class ProtocolWizardNumberBase(CoordinatorEntity, NumberEntity):
         if register_type in ("coil", "discrete"):
             value = bool(int(float(value)))  # "0" → False, "1" → True
         elif "float" not in self.data_type:
-            value = int(round(float(value)))  # Regular registers
+            value = round(float(value))  # Regular registers
         else:
             value = float(value)  # Float registers
         
@@ -711,7 +710,7 @@ class ProtocolWizardSelectBase(CoordinatorEntity, SelectEntity):
                 elif "float" in self._config.get("data_type", ""):
                     value = float(value)
                 else:
-                    value = int(round(float(value)))  # Regular registers
+                    value = round(float(value))  # Regular registers
     
             elif protocol == CONF_PROTOCOL_BACNET:
                 # BACnet: convert based on data type
@@ -899,8 +898,9 @@ def get_all_coordinators_for_entry(hass: HomeAssistant, entry: ConfigEntry):
     Returns list of (coordinator, device_info) tuples.
     Handles multi-slave Modbus and multi-device BACnet.
     """
-    from .const import DOMAIN, CONF_SLAVES, CONF_PROTOCOL, CONF_PROTOCOL_MODBUS
     from homeassistant.helpers.entity import DeviceInfo
+
+    from .const import CONF_PROTOCOL, CONF_PROTOCOL_MODBUS, CONF_SLAVES, DOMAIN
 
     coordinator_keys = hass.data[DOMAIN].get("entry_coordinator_keys", {}).get(
         entry.entry_id, [entry.entry_id]

--- a/custom_components/protocol_wizard/number.py
+++ b/custom_components/protocol_wizard/number.py
@@ -5,11 +5,16 @@
 from __future__ import annotations
 
 import logging
-from homeassistant.core import HomeAssistant
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .entity_base import BaseEntityManager, ProtocolWizardNumberBase, get_all_coordinators_for_entry
+from .entity_base import (
+    BaseEntityManager,
+    ProtocolWizardNumberBase,
+    get_all_coordinators_for_entry,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/protocol_wizard/options_flow.py
+++ b/custom_components/protocol_wizard/options_flow.py
@@ -4,35 +4,38 @@
 """Options flow for Protocol Wizard – fully protocol-agnostic."""
 from __future__ import annotations
 
-import logging
 import json
+import logging
 from datetime import timedelta
+
 import voluptuous as vol
-from .template_utils import ( 
-    save_template, 
-    get_available_templates, 
-    get_template_dropdown_choices, 
-    load_template,
-    delete_template,
-)
 from homeassistant import config_entries
-from homeassistant.helpers import selector, device_registry as dr
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import selector
+
 #import asyncio
 from .const import (
-    DOMAIN,
-    CONF_UPDATE_INTERVAL,
-    CONF_ENTITIES,
-    CONF_REGISTERS,
-    CONF_PROTOCOL,
-    CONF_PROTOCOL_MODBUS,
-    CONF_PROTOCOL_SNMP,
-    CONF_PROTOCOL_MQTT,
-    CONF_PROTOCOL_BACNET,
-    CONF_BYTE_ORDER,
-    CONF_WORD_ORDER,
-    CONF_REGISTER_TYPE,
-    CONF_SLAVES,
     CONF_BACNET_DEVICES,
+    CONF_BYTE_ORDER,
+    CONF_ENTITIES,
+    CONF_PROTOCOL,
+    CONF_PROTOCOL_BACNET,
+    CONF_PROTOCOL_MODBUS,
+    CONF_PROTOCOL_MQTT,
+    CONF_PROTOCOL_SNMP,
+    CONF_REGISTER_TYPE,
+    CONF_REGISTERS,
+    CONF_SLAVES,
+    CONF_UPDATE_INTERVAL,
+    CONF_WORD_ORDER,
+    DOMAIN,
+)
+from .template_utils import (
+    delete_template,
+    get_available_templates,
+    get_template_dropdown_choices,
+    load_template,
+    save_template,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/protocol_wizard/protocols/__init__.py
+++ b/custom_components/protocol_wizard/protocols/__init__.py
@@ -2,13 +2,15 @@
 #-- protocol init.py protocol wizard
 #------------------------------------------
 """Protocol registry for Protocol Wizard."""
-from typing import Dict, Type
+from __future__ import annotations
+
 from .base import BaseProtocolCoordinator
+
 
 class ProtocolRegistry:
     """Registry of available protocols."""
     
-    _protocols: Dict[str, Type[BaseProtocolCoordinator]] = {}
+    _protocols: dict[str, type[BaseProtocolCoordinator]] = {}
     
     @classmethod
     def register(cls, protocol_name: str):
@@ -19,7 +21,7 @@ class ProtocolRegistry:
         return wrapper
     
     @classmethod
-    def get_coordinator_class(cls, protocol_name: str) -> Type[BaseProtocolCoordinator] | None:
+    def get_coordinator_class(cls, protocol_name: str) -> type[BaseProtocolCoordinator] | None:
         """Get coordinator class for protocol."""
         return cls._protocols.get(protocol_name)
     

--- a/custom_components/protocol_wizard/protocols/bacnet/__init__.py
+++ b/custom_components/protocol_wizard/protocols/bacnet/__init__.py
@@ -2,28 +2,28 @@
 #-- protocol BACnet init.py protocol wizard
 #------------------------------------------
 """BACnet protocol plugin."""
-from .coordinator import BACnetCoordinator
 from .client import BACnetClient
 from .const import (
-    CONF_ENTITIES,
     BACNET_DATA_TYPES,
     BACNET_OBJECT_TYPES,
     BACNET_PROPERTIES,
     BACNET_UNITS,
+    CONF_ENTITIES,
     entity_key,
-    parse_bacnet_address,
     format_bacnet_address,
+    parse_bacnet_address,
 )
+from .coordinator import BACnetCoordinator
 
 __all__ = [
-    "BACnetCoordinator",
-    "BACnetClient", 
-    "CONF_ENTITIES",
     "BACNET_DATA_TYPES",
     "BACNET_OBJECT_TYPES",
     "BACNET_PROPERTIES",
     "BACNET_UNITS",
+    "CONF_ENTITIES",
+    "BACnetClient",
+    "BACnetCoordinator",
     "entity_key",
-    "parse_bacnet_address",
     "format_bacnet_address",
+    "parse_bacnet_address",
 ]

--- a/custom_components/protocol_wizard/protocols/bacnet/client.py
+++ b/custom_components/protocol_wizard/protocols/bacnet/client.py
@@ -1,24 +1,28 @@
 # protocols/bacnet/client.py
 """BACnet/IP client for Protocol Wizard using bacpypes3 - proper initialization."""
 
-import logging
 import asyncio
-from typing import Any, Optional
+import logging
+from typing import Any
+
+from homeassistant.components.network import async_get_adapters, async_get_source_ip
 from homeassistant.core import HomeAssistant
-from homeassistant.components.network import async_get_source_ip, async_get_adapters
+
 #import sys
 
 _LOGGER = logging.getLogger(__name__)
 
 try:
 #    from bacpypes3.settings import settings
+    #    from bacpypes3.argparse import SimpleArgumentParser, create_log_handler
+    import ipaddress
+
     from bacpypes3.app import Application
-#    from bacpypes3.local.device import DeviceObject
-    from bacpypes3.primitivedata import ObjectIdentifier
     from bacpypes3.basetypes import PropertyIdentifier
     from bacpypes3.pdu import Address, LocalBroadcast
-#    from bacpypes3.argparse import SimpleArgumentParser, create_log_handler
-    import ipaddress
+
+    #    from bacpypes3.local.device import DeviceObject
+    from bacpypes3.primitivedata import ObjectIdentifier
     HAS_BACPYPES3 = True
 except ImportError:
     HAS_BACPYPES3 = False
@@ -60,7 +64,7 @@ async def get_my_lan_ip_and_subnet(hass):
     # 2. Fallback: first private LAN IP
     for entry in summary:
         ip = entry["ip"]
-        if ip.startswith("192.168.") or ip.startswith("10.") or ip.startswith("172."):
+        if ip.startswith(("192.168.", "10.", "172.")):
             return entry["ip"], entry["prefix"]
 
     # 3. Last resort: first IP
@@ -103,9 +107,9 @@ class BACnetClient:
         self, 
         hass: HomeAssistant,
         host: str, 
-        device_id: Optional[int] = None,
+        device_id: int | None = None,
         port: int = 47808,
-        network_number: Optional[int] = 0
+        network_number: int | None = 0
     ):
         """Initialize BACnet client."""
         if not HAS_BACPYPES3:
@@ -115,7 +119,7 @@ class BACnetClient:
         self.device_id = device_id
         self.port = port
         self.network_number = network_number
-        self.app: Optional[Application] = None
+        self.app: Application | None = None
         self._connected = False
         self.hass = hass
         self._bacpypeinstance = None
@@ -124,8 +128,8 @@ class BACnetClient:
         """Initialize bacpypes3 properly using from_args pattern."""
         if not self._bacpypeinstance:
             try:
-                from argparse import Namespace
                 import random
+                from argparse import Namespace
         
                 source_ip = address_adapter = ip_to_use = self.host
 
@@ -321,7 +325,7 @@ class BACnetClient:
         return devices
     
     
-    async def get_device_name(self) -> Optional[str]:
+    async def get_device_name(self) -> str | None:
         """Get device name."""
         try:
             if not self._connected or not self.device_id:
@@ -339,7 +343,7 @@ class BACnetClient:
         object_type: str, 
         object_instance: int, 
         property_name: str
-    ) -> Optional[Any]:
+    ) -> Any | None:
         """Read BACnet property."""
         if not self._connected or not self.app:
             _LOGGER.error("Not connected to BACnet network")

--- a/custom_components/protocol_wizard/protocols/bacnet/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/bacnet/coordinator.py
@@ -1,17 +1,20 @@
 # protocols/bacnet/coordinator.py
 """BACnet coordinator for Protocol Wizard."""
 
-import logging
-from typing import Any
 import asyncio
+import logging
 from datetime import timedelta
-from .. import ProtocolRegistry
-from ...protocols.base import BaseProtocolCoordinator
-from homeassistant.core import HomeAssistant
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
-from .const import parse_bacnet_address, entity_key
+from homeassistant.core import HomeAssistant
+
+from ...const import CONF_BACNET_DEVICES, CONF_ENTITIES, CONF_PROTOCOL_BACNET
+from ...protocols.base import BaseProtocolCoordinator
+from .. import ProtocolRegistry
 from .client import BACnetClient
-from ...const import CONF_ENTITIES, CONF_PROTOCOL_BACNET, CONF_BACNET_DEVICES
+from .const import entity_key, parse_bacnet_address
+
 _LOGGER = logging.getLogger(__name__)
 
 @ProtocolRegistry.register(CONF_PROTOCOL_BACNET)

--- a/custom_components/protocol_wizard/protocols/base.py
+++ b/custom_components/protocol_wizard/protocols/base.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any
 from datetime import timedelta
+from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.config_entries import ConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,28 +28,23 @@ class BaseProtocolClient(ABC):
     @abstractmethod
     async def connect(self) -> bool:
         """Establish connection. Returns True if successful."""
-        pass
     
     @abstractmethod
     async def disconnect(self) -> None:
         """Close connection."""
-        pass
     
     @abstractmethod
     async def read(self, address: str, **kwargs) -> Any:
         """Read value from address. Protocol-specific kwargs."""
-        pass
     
     @abstractmethod
     async def write(self, address: str, value: Any, **kwargs) -> bool:
         """Write value to address. Returns True if successful."""
-        pass
     
     @property
     @abstractmethod
     def is_connected(self) -> bool:
         """Connection status."""
-        pass
 
 class _SafeFormatDict(dict):
     """Returns placeholder unchanged if key is missing."""
@@ -87,7 +82,6 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
         Should return a dict where keys are entity identifiers
         and values are the decoded/processed values.
         """
-        pass
     
     @abstractmethod
     def _decode_value(self, raw_value: Any, entity_config: dict) -> Any:
@@ -101,7 +95,6 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
         Returns:
             Decoded Python value (int, float, str, bool, etc.)
         """
-        pass
     
     @abstractmethod
     def _encode_value(self, value: Any, entity_config: dict) -> Any:
@@ -115,7 +108,6 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
         Returns:
             Protocol-specific encoded value
         """
-        pass
 
     def _format_value(self, value: Any, entity_config: dict) -> Any:
         format_str = str(entity_config.get("format", "")).strip()
@@ -185,7 +177,6 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
         Returns:
             Decoded value or None if failed
         """
-        pass
     
     @abstractmethod
     async def async_write_entity(
@@ -207,7 +198,6 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
         Returns:
             True if successful
         """
-        pass
     
     async def _async_connect(self) -> bool:
         """

--- a/custom_components/protocol_wizard/protocols/modbus/__init__.py
+++ b/custom_components/protocol_wizard/protocols/modbus/__init__.py
@@ -2,8 +2,8 @@
 #-- protocol modbus init.py protocol wizard
 #------------------------------------------
 """Modbus protocol plugin."""
-from .coordinator import ModbusCoordinator
 from .client import ModbusClient
 from .const import CONF_REGISTERS, TYPE_SIZES, reg_key
+from .coordinator import ModbusCoordinator
 
-__all__ = ["ModbusCoordinator", "ModbusClient", "CONF_REGISTERS", "TYPE_SIZES", "reg_key"]
+__all__ = ["CONF_REGISTERS", "TYPE_SIZES", "ModbusClient", "ModbusCoordinator", "reg_key"]

--- a/custom_components/protocol_wizard/protocols/modbus/client.py
+++ b/custom_components/protocol_wizard/protocols/modbus/client.py
@@ -4,8 +4,8 @@
 """Modbus protocol client wrapper."""
 from __future__ import annotations
 
-import logging
 import asyncio
+import logging
 from typing import Any
 
 from pymodbus.exceptions import ModbusIOException

--- a/custom_components/protocol_wizard/protocols/modbus/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/modbus/coordinator.py
@@ -4,20 +4,20 @@
 """Modbus protocol coordinator implementation."""
 from __future__ import annotations
 
-import logging
 import asyncio
-from typing import Any
+import logging
 from datetime import timedelta
+from typing import Any
 
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from pymodbus.client.mixin import ModbusClientMixin
-from .client import ModbusClient
 
-from ..base import BaseProtocolCoordinator
+from ...const import CONF_REGISTERS, CONF_SLAVES
 from .. import ProtocolRegistry
+from ..base import BaseProtocolCoordinator
+from .client import ModbusClient
 from .const import TYPE_SIZES, reg_key
-from ...const import CONF_REGISTERS,CONF_SLAVES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -355,7 +355,7 @@ class ModbusCoordinator(BaseProtocolCoordinator):
             # Single register integer
             if data_type in ("uint16", "int16"):
                 try:
-                    value = int(round(float(value)))
+                    value = round(float(value))
                 except Exception:
                     _LOGGER.error("Failed to convert to int for %s: %s", data_type, original_value)
                     return None
@@ -379,7 +379,7 @@ class ModbusCoordinator(BaseProtocolCoordinator):
         if target_type == ModbusClientMixin.DATATYPE.FLOAT32:
             value = float(value)
         else:
-            value = int(round(float(value)))
+            value = round(float(value))
     
         try:
             return self.client.raw_client.convert_to_registers(

--- a/custom_components/protocol_wizard/protocols/mqtt/__init__.py
+++ b/custom_components/protocol_wizard/protocols/mqtt/__init__.py
@@ -1,26 +1,26 @@
 # custom_components/protocol_wizard/protocols/mqtt/__init__.py
 """MQTT protocol implementation."""
-from .client import MQTTClient
-from .coordinator import MQTTCoordinator
 from ...const import CONF_ENTITIES, CONF_PORT
+from .client import MQTTClient
 from .const import (
     CONF_BROKER,
-    CONF_USERNAME,
     CONF_PASSWORD,
-    DEFAULT_PORT,
+    CONF_USERNAME,
     DATA_TYPES,
+    DEFAULT_PORT,
     topic_key,
 )
+from .coordinator import MQTTCoordinator
 
 __all__ = [
-    "MQTTClient",
-    "MQTTCoordinator",
-    "CONF_ENTITIES",
     "CONF_BROKER",
+    "CONF_ENTITIES",
+    "CONF_PASSWORD",
     "CONF_PORT",
     "CONF_USERNAME",
-    "CONF_PASSWORD",
-    "DEFAULT_PORT",
     "DATA_TYPES",
+    "DEFAULT_PORT",
+    "MQTTClient",
+    "MQTTCoordinator",
     "topic_key"
 ]

--- a/custom_components/protocol_wizard/protocols/mqtt/client.py
+++ b/custom_components/protocol_wizard/protocols/mqtt/client.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import json
+import logging
 from typing import Any
 
 import paho.mqtt.client as mqtt_client

--- a/custom_components/protocol_wizard/protocols/mqtt/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/mqtt/coordinator.py
@@ -2,19 +2,19 @@
 """MQTT protocol coordinator implementation - Event-Driven Architecture."""
 from __future__ import annotations
 
-import logging
-from typing import Any
-from datetime import timedelta
 import asyncio
 import json
+import logging
+from datetime import timedelta
+from typing import Any
 
-from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
-from ..base import BaseProtocolCoordinator
-from .. import ProtocolRegistry
-from .client import MQTTClient
 from ...const import CONF_ENTITIES, CONF_PROTOCOL_MQTT
+from .. import ProtocolRegistry
+from ..base import BaseProtocolCoordinator
+from .client import MQTTClient
 from .const import topic_key
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/protocol_wizard/protocols/snmp/__init__.py
+++ b/custom_components/protocol_wizard/protocols/snmp/__init__.py
@@ -3,8 +3,8 @@
 #------------------------------------------
 
 """SNMP protocol plugin."""
-from .coordinator import SNMPCoordinator
 from .client import SNMPClient
 from .const import CONF_ENTITIES, SNMP_DATA_TYPES, oid_key
+from .coordinator import SNMPCoordinator
 
-__all__ = ["SNMPCoordinator", "SNMPClient", "CONF_ENTITIES", "SNMP_DATA_TYPES", "oid_key"]
+__all__ = ["CONF_ENTITIES", "SNMP_DATA_TYPES", "SNMPClient", "SNMPCoordinator", "oid_key"]

--- a/custom_components/protocol_wizard/protocols/snmp/client.py
+++ b/custom_components/protocol_wizard/protocols/snmp/client.py
@@ -7,12 +7,12 @@ import logging
 from typing import Any
 
 from pysnmp.hlapi.v3arch.asyncio import (
-    SnmpEngine,
     CommunityData,
-    UdpTransportTarget,
     ContextData,
-    ObjectType,
     ObjectIdentity,
+    ObjectType,
+    SnmpEngine,
+    UdpTransportTarget,
     get_cmd,
     set_cmd,
     walk_cmd,

--- a/custom_components/protocol_wizard/protocols/snmp/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/snmp/coordinator.py
@@ -2,15 +2,16 @@
 """SNMP protocol coordinator implementation."""
 from __future__ import annotations
 
-import logging
-from typing import Any
-from datetime import timedelta
 import asyncio
-from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
+import logging
+from datetime import timedelta
+from typing import Any
 
-from ..base import BaseProtocolCoordinator
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
 from .. import ProtocolRegistry
+from ..base import BaseProtocolCoordinator
 from .client import SNMPClient
 from .const import CONF_ENTITIES, oid_key
 
@@ -176,7 +177,7 @@ class SNMPCoordinator(BaseProtocolCoordinator):
                     value = (value - offset) / scale
 
                 if data_type != "float":
-                    value = int(round(float(value)))
+                    value = round(float(value))
 
             # pysnmp handles type mapping — just return clean Python value
             return value

--- a/custom_components/protocol_wizard/select.py
+++ b/custom_components/protocol_wizard/select.py
@@ -5,11 +5,16 @@
 from __future__ import annotations
 
 import logging
-from homeassistant.core import HomeAssistant
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .entity_base import BaseEntityManager, ProtocolWizardSelectBase, get_all_coordinators_for_entry
+from .entity_base import (
+    BaseEntityManager,
+    ProtocolWizardSelectBase,
+    get_all_coordinators_for_entry,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/protocol_wizard/sensor.py
+++ b/custom_components/protocol_wizard/sensor.py
@@ -5,16 +5,17 @@
 from __future__ import annotations
 
 import logging
-from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
 
-from .const import DOMAIN, CONF_PROTOCOL, CONF_PROTOCOL_MODBUS
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_PROTOCOL, CONF_PROTOCOL_MODBUS, DOMAIN
 from .entity_base import (
     BaseEntityManager,
-    ProtocolWizardSensorBase,
-    ProtocolWizardHubEntity,
-    ModbusSlaveIdEntity,
     ModbusConnectionInfoEntity,
+    ModbusSlaveIdEntity,
+    ProtocolWizardHubEntity,
+    ProtocolWizardSensorBase,
     get_all_coordinators_for_entry,
 )
 

--- a/custom_components/protocol_wizard/switch.py
+++ b/custom_components/protocol_wizard/switch.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import logging
-from homeassistant.core import HomeAssistant
+
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
-from .entity_base import BaseEntityManager, ProtocolWizardSwitchBase, get_all_coordinators_for_entry
+from .entity_base import (
+    BaseEntityManager,
+    ProtocolWizardSwitchBase,
+    get_all_coordinators_for_entry,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/protocol_wizard/template_utils.py
+++ b/custom_components/protocol_wizard/template_utils.py
@@ -6,15 +6,22 @@ with a single, consistent interface supporting both built-in and user templates.
 """
 from __future__ import annotations
 
-import logging
 import json
+import logging
+
 #import os
 from pathlib import Path
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, CONF_PROTOCOL_MODBUS, CONF_PROTOCOL_SNMP , CONF_PROTOCOL_MQTT, CONF_PROTOCOL_BACNET
+from .const import (
+    CONF_PROTOCOL_BACNET,
+    CONF_PROTOCOL_MODBUS,
+    CONF_PROTOCOL_MQTT,
+    CONF_PROTOCOL_SNMP,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +68,7 @@ def ensure_user_template_dirs(hass: HomeAssistant) -> None:
     try:
         base_path = Path(hass.config.path(USER_TEMPLATES_DIR))
         
-        for protocol in PROTOCOL_SUBDIRS.keys():
+        for protocol in PROTOCOL_SUBDIRS:
             protocol_dir = base_path / protocol
             protocol_dir.mkdir(parents=True, exist_ok=True)
         
@@ -369,7 +376,7 @@ async def get_available_templates_legacy(
     Returns list of filenames without .json extension, from both directories.
     """
     templates = await get_available_templates(hass, protocol)
-    return [tid.split(":", 1)[1] for tid in templates.keys()]
+    return [tid.split(":", 1)[1] for tid in templates]
 
 
 async def load_template_legacy(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import sys
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/test_bacnet_coordinator.py
+++ b/tests/test_bacnet_coordinator.py
@@ -1,8 +1,9 @@
 """Tests for BACnet coordinator decode/encode logic."""
 from __future__ import annotations
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from custom_components.protocol_wizard.protocols.bacnet.coordinator import (
     BACnetCoordinator,

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -4,35 +4,37 @@ from __future__ import annotations
 import pytest
 
 from custom_components.protocol_wizard.const import (
-    DOMAIN,
-    SIGNAL_ENTITY_SYNC,
-    CONF_PROTOCOL_MODBUS,
-    CONF_PROTOCOL_SNMP,
-    CONF_PROTOCOL_MQTT,
     CONF_PROTOCOL_BACNET,
-    DEFAULT_SLAVE_ID,
+    CONF_PROTOCOL_MODBUS,
+    CONF_PROTOCOL_MQTT,
+    CONF_PROTOCOL_SNMP,
     DEFAULT_BAUDRATE,
+    DEFAULT_SLAVE_ID,
     DEFAULT_TCP_PORT,
     DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    SIGNAL_ENTITY_SYNC,
+)
+from custom_components.protocol_wizard.protocols.bacnet.const import (
+    BACNET_DATA_TYPES,
+    BACNET_OBJECT_TYPES,
+    entity_key,
+    format_bacnet_address,
+    parse_bacnet_address,
 )
 from custom_components.protocol_wizard.protocols.modbus.const import (
     TYPE_SIZES,
     reg_key,
 )
+from custom_components.protocol_wizard.protocols.mqtt.const import (
+    DATA_TYPES as MQTT_DATA_TYPES,
+)
+from custom_components.protocol_wizard.protocols.mqtt.const import (
+    topic_key,
+)
 from custom_components.protocol_wizard.protocols.snmp.const import (
     SNMP_DATA_TYPES,
     oid_key,
-)
-from custom_components.protocol_wizard.protocols.mqtt.const import (
-    DATA_TYPES as MQTT_DATA_TYPES,
-    topic_key,
-)
-from custom_components.protocol_wizard.protocols.bacnet.const import (
-    parse_bacnet_address,
-    format_bacnet_address,
-    entity_key,
-    BACNET_OBJECT_TYPES,
-    BACNET_DATA_TYPES,
 )
 
 

--- a/tests/test_entity_base.py
+++ b/tests/test_entity_base.py
@@ -4,15 +4,14 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from custom_components.protocol_wizard.entity_base import (
-    get_safe_number_defaults,
     apply_common_entity_attributes,
+    get_safe_number_defaults,
     set_readonly_protocol_settings,
 )
-from custom_components.protocol_wizard.sensor import SensorManager
 from custom_components.protocol_wizard.number import NumberManager
-from custom_components.protocol_wizard.switch import SwitchManager
 from custom_components.protocol_wizard.select import SelectManager
-
+from custom_components.protocol_wizard.sensor import SensorManager
+from custom_components.protocol_wizard.switch import SwitchManager
 
 # ---------------------------------------------------------------------------
 # get_safe_number_defaults
@@ -77,8 +76,8 @@ class TestApplyCommonEntityAttributes:
 
     def _make_entity(self, entity_type="sensor"):
         """Create a mock entity with the right base classes."""
-        from homeassistant.components.sensor import SensorEntity
         from homeassistant.components.number import NumberEntity
+        from homeassistant.components.sensor import SensorEntity
 
         if entity_type == "sensor":
             entity = MagicMock(spec=SensorEntity)

--- a/tests/test_template_utils.py
+++ b/tests/test_template_utils.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 import json
 import os
 import tempfile
-import pytest
 from pathlib import Path
 
+import pytest
+
 from custom_components.protocol_wizard.template_utils import (
+    PROTOCOL_SUBDIRS,
     get_protocol_subdir,
     get_template_dropdown_choices,
-    PROTOCOL_SUBDIRS,
 )
 
 


### PR DESCRIPTION
- Sort and format all import blocks (I001)
- Remove unnecessary pass in abstract methods (PIE790)
- Replace deprecated typing.Dict/Type with builtins (UP035/UP006)
- Replace Optional[X] with X | None (UP045)
- Sort __all__ lists (RUF022)
- Remove redundant int(round(...)) casts (RUF046)
- Use f-string conversion flags (RUF010)
- Simplify dict key checks (RUF019, SIM118)
- Merge startswith calls into tuple (PIE810)
- Remove unused imports

https://claude.ai/code/session_0141XkQRjcng4RKLD4Yv5FAr