### PR TITLE
Fix 89 remaining ruff lint errors (BLE001, G201, TRY, SIM, RUF012)

### DIFF
--- a/custom_components/protocol_wizard/__init__.py
+++ b/custom_components/protocol_wizard/__init__.py
@@ -93,7 +93,7 @@ async def async_install_frontend_resource(hass: HomeAssistant):
             else:
                 _LOGGER.warning("Frontend source file missing at %s", source_path)
 
-        except Exception as err:
+        except OSError as err:
             _LOGGER.error("Failed to install frontend resource: %s", err)
 
     await hass.async_add_executor_job(install)
@@ -428,7 +428,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         else:
             _LOGGER.error("Protocol %s not yet implemented", protocol_name)
             return False
-    except Exception as err:
+    except (OSError, ConnectionError, TimeoutError, ValueError) as err:
         _LOGGER.error("Failed to create client for %s: %s", protocol_name, err)
         return False
 
@@ -545,7 +545,7 @@ async def _load_template_into_options(
 
         hass.config_entries.async_update_entry(entry, options=new_options)
 
-    except Exception as err:
+    except (OSError, KeyError, TypeError, ValueError) as err:
         _LOGGER.error("Failed to load template %s: %s", template_name, err)
 
 
@@ -880,7 +880,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             }
 
         except Exception as err:
-            _LOGGER.error("Failed to add entity: %s", err, exc_info=True)
+            _LOGGER.exception("Failed to add entity")
             raise HomeAssistantError(f"Failed to add entity: {err!s}") from err
 
     async def handle_write_register(call: ServiceCall):
@@ -912,7 +912,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 raise HomeAssistantError(f"Write failed for address {address}")
 
         except Exception as err:
-            _LOGGER.error("Unexpected exception in write_register service for address %s: %s", address, err, exc_info=True)
+            _LOGGER.exception("Unexpected exception in write_register service for address %s", address)
             raise HomeAssistantError(f"Write failed for address {address}: {err!s}") from err
 
     async def handle_read_register(call: ServiceCall):
@@ -1066,7 +1066,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 address=address,
                 entity_config=entity_config,
             )
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.debug("BACnet Read failed with error: %s", err)
         if value is None:
             raise HomeAssistantError(f"Failed to read BACnet address {address}")
@@ -1105,7 +1105,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 value=value,
                 entity_config=entity_config,
             )
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.debug("BACnet write failed with error: %s", err)
 
         if not success:
@@ -1188,7 +1188,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if not still_used:
                 try:
                     await client.disconnect()
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001
                     _LOGGER.debug("Error closing Modbus client: %s", err)
     else:
         # Other protocols (SNMP, MQTT, etc.)
@@ -1205,7 +1205,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if not still_used:
                 try:
                     await client.disconnect()
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001
                     _LOGGER.debug("Error closing client: %s", err)
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/protocol_wizard/config_flow.py
+++ b/custom_components/protocol_wizard/config_flow.py
@@ -318,8 +318,8 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
 
-            except Exception as err:
-                _LOGGER.exception("Connection test failed: %s", err)
+            except (OSError, ConnectionError, TimeoutError):
+                _LOGGER.exception("Connection test failed")
                 errors["base"] = "cannot_connect"
 
         # Get available templates
@@ -435,7 +435,7 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         if not result.isError() and hasattr(result, "registers") and len(result.registers) == count:
                             success = True
                             break
-                except Exception as inner_err:
+                except (OSError, ConnectionError, TimeoutError) as inner_err:
                     _LOGGER.debug("Test read failed for %s at addr %d: %s", name, address, inner_err)
 
             if not success:
@@ -449,7 +449,7 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if client:
                 try:
                     client.close()
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001
                     _LOGGER.debug("Error closing Modbus client: %s", err)
 
     # ================================================================
@@ -493,8 +493,8 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     options=options,
                 )
 
-            except Exception as err:
-                _LOGGER.exception("SNMP connection test failed: %s", err)
+            except (OSError, ConnectionError, TimeoutError):
+                _LOGGER.exception("SNMP connection test failed")
                 errors["base"] = "cannot_connect"
 
         # Get available templates
@@ -636,7 +636,7 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except asyncio.TimeoutError:
             _LOGGER.warning("BACnet discovery timed out")
             errors["base"] = "discovery_timeout"
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("BACnet discovery failed: %s", err)
             errors["base"] = "discovery_failed"
         finally:
@@ -644,7 +644,7 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 try:
                     await discovery_client.disconnect()
                     _LOGGER.info("Discovery client disconnected")
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001
                     _LOGGER.warning("Error disconnecting discovery client: %s", err)
 
         # If no devices found or error, show option to go manual
@@ -785,7 +785,7 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                 else:
                     errors["base"] = "cannot_connect"
-            except Exception as err:
+            except (OSError, ConnectionError, TimeoutError) as err:
                 _LOGGER.error("BACnet connection test failed: %s", err)
                 errors["base"] = "unknown"
 
@@ -873,8 +873,8 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     options=options,
                 )
 
-            except Exception as err:
-                _LOGGER.exception("MQTT connection test failed: %s", err)
+            except (OSError, ConnectionError, TimeoutError):
+                _LOGGER.exception("MQTT connection test failed")
                 errors["base"] = "cannot_connect"
 
         # Get available templates
@@ -936,21 +936,21 @@ class ProtocolWizardConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             connected = await client.connect()
 
             if not connected:
-                raise Exception("Could not connect to MQTT broker")
+                raise ConnectionError("Could not connect to MQTT broker")
 
             _LOGGER.info("MQTT connection test successful to %s:%s",
                         config[CONF_BROKER], config[CONF_PORT])
 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("MQTT connection test failed: %s", err)
-            raise Exception(
+            raise ConnectionError(
                 f"Cannot connect to MQTT broker at {config[CONF_BROKER]}:{config[CONF_PORT]}. "
                 "Check broker address, port, and credentials."
-            )
+            ) from err
 
         finally:
             if client:
                 try:
                     await client.disconnect()
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001
                     _LOGGER.debug("Error disconnecting MQTT client: %s", err)

--- a/custom_components/protocol_wizard/entity_base.py
+++ b/custom_components/protocol_wizard/entity_base.py
@@ -625,7 +625,7 @@ class ProtocolWizardSelectBase(CoordinatorEntity, SelectEntity):
         if isinstance(options_raw, str):
             try:
                 options_dict = json.loads(options_raw)
-            except Exception:
+            except (json.JSONDecodeError, ValueError):
                 _LOGGER.error(
                     "Invalid options JSON for %s: %r",
                     entity_config.get("name"),
@@ -744,7 +744,7 @@ class ProtocolWizardSelectBase(CoordinatorEntity, SelectEntity):
             else:
                 _LOGGER.error("Failed to write value to %s", self._config.get("name"))
     
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, ValueError, TypeError) as err:
             _LOGGER.error("Error in async_select_option: %s", err)
             import traceback
             traceback.print_exc()
@@ -798,7 +798,7 @@ class ProtocolWizardHubEntity(CoordinatorEntity, SensorEntity):
     def native_value(self):
         try:
             return "connected" if self.coordinator.client.is_connected else "disconnected"
-        except Exception as err:
+        except (AttributeError, OSError, ConnectionError) as err:
             _LOGGER.debug("Failed to get hub status: %s", err)
             return "unknown"
 

--- a/custom_components/protocol_wizard/options_flow.py
+++ b/custom_components/protocol_wizard/options_flow.py
@@ -788,7 +788,7 @@ class ModbusSchemaHandler:
                 processed["options"] = json.loads(processed["options"])
                 if not isinstance(processed["options"], dict):
                     processed["options"]="" # if it is rubish, we dont use it
-            except Exception:
+            except (json.JSONDecodeError, ValueError):
                 errors["options"] = ""
         # Update with new values, handling empty strings properly
         for key, value in user_input.items():

--- a/custom_components/protocol_wizard/protocols/__init__.py
+++ b/custom_components/protocol_wizard/protocols/__init__.py
@@ -4,13 +4,15 @@
 """Protocol registry for Protocol Wizard."""
 from __future__ import annotations
 
+from typing import ClassVar
+
 from .base import BaseProtocolCoordinator
 
 
 class ProtocolRegistry:
     """Registry of available protocols."""
-    
-    _protocols: dict[str, type[BaseProtocolCoordinator]] = {}
+
+    _protocols: ClassVar[dict[str, type[BaseProtocolCoordinator]]] = {}
     
     @classmethod
     def register(cls, protocol_name: str):

--- a/custom_components/protocol_wizard/protocols/bacnet/client.py
+++ b/custom_components/protocol_wizard/protocols/bacnet/client.py
@@ -85,7 +85,7 @@ def calculate_broadcast_address(ip_with_subnet):
         _LOGGER.debug("Network: %s, Broadcast: %s", network.network_address, broadcast)
 
         return ip, netmask, broadcast
-    except Exception as e:
+    except (ValueError, TypeError) as e:
         _LOGGER.error("Failed to calculate broadcast address from %s: %s", ip_with_subnet, e)
         return None, None, None
     
@@ -135,11 +135,11 @@ class BACnetClient:
 
                 try:
                     address_adapter = await get_my_lan_ip_and_subnet(hass)
-                except Exception as err:
+                except (OSError, ConnectionError, TimeoutError) as err:
                     _LOGGER.warning("Error in getting adapter info: %s",  err)
                 try:
                     source_ip = await async_get_source_ip(hass)
-                except Exception as err:
+                except (OSError, ConnectionError, TimeoutError) as err:
                     _LOGGER.warning("Error in getting HA local IP info: %s",  err)
 
                 if self.host == "0.0.0.0": # Discovery mode - use actual IP
@@ -198,7 +198,7 @@ class BACnetClient:
 
                 return theApp
                 
-            except Exception as err:
+            except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
                 _LOGGER.error("Failed to initialize bacpypes3: %s", err)
                 import traceback
                 traceback.print_exc()
@@ -222,7 +222,7 @@ class BACnetClient:
             _LOGGER.debug("[BACnet] Connected successfully, app=%s", type(self.app).__name__)
             return True
 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
             _LOGGER.error("[BACnet] Connection failed: %s", err)
             import traceback
             traceback.print_exc()
@@ -254,7 +254,7 @@ class BACnetClient:
 
                 await asyncio.sleep(0.5)
 
-            except Exception as err:
+            except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
                 _LOGGER.error("Who-Is failed: %s", err)
                 return []
 
@@ -266,7 +266,7 @@ class BACnetClient:
             _LOGGER.debug("Discovered %d BACnet devices", len(devices))
             return devices
 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
             _LOGGER.error("BACnet discovery failed: %s", err)
             return []
     
@@ -316,10 +316,10 @@ class BACnetClient:
                         'vendor': vendor,
                     })
 
-                except Exception as err:
+                except (ValueError, TypeError) as err:
                     _LOGGER.warning("Error parsing device %s: %s", device_id, err)
 
-        except Exception as err:
+        except (ValueError, TypeError) as err:
             _LOGGER.error("Error collecting discovered devices: %s", err)
 
         return devices
@@ -333,7 +333,7 @@ class BACnetClient:
             
             name = await self.read_property("device", self.device_id, "objectName")
             return name
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
             _LOGGER.warning("Could not read device name: %s", err)
             return None
     
@@ -371,8 +371,8 @@ class BACnetClient:
                 _LOGGER.warning("[BACnet] Read timed out after 5s - no response from %s for %s", device_address, object_id)
                 return None
         
-        except Exception as err:
-            _LOGGER.error("Read failed for %s:%s.%s: %s", 
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
+            _LOGGER.error("Read failed for %s:%s.%s: %s",
                          object_type, object_instance, property_name, err)
             import traceback
             traceback.print_exc()
@@ -408,8 +408,8 @@ class BACnetClient:
             _LOGGER.debug("Wrote %s to %s:%s.%s", value, object_type, object_instance, property_name)
             return True
         
-        except Exception as err:
-            _LOGGER.error("Write failed for %s:%s.%s: %s", 
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
+            _LOGGER.error("Write failed for %s:%s.%s: %s",
                          object_type, object_instance, property_name, err)
             import traceback
             traceback.print_exc()
@@ -429,7 +429,7 @@ class BACnetClient:
                                     await link_layer.close()
                                 else:
                                     link_layer.close()
-                        except Exception as err:
+                        except Exception as err:  # noqa: BLE001
                             _LOGGER.debug("Error closing link layer %s: %s", port_id, err)
 
                 # Close the application
@@ -448,8 +448,8 @@ class BACnetClient:
 
                 _LOGGER.debug("BACnet disconnected")
 
-            except Exception as err:
-                _LOGGER.error("Error disconnecting BACnet: %s", err)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Error disconnecting BACnet: %s", err)
             finally:
                 self.app = None
                 self._bacpypeinstance = None

--- a/custom_components/protocol_wizard/protocols/bacnet/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/bacnet/coordinator.py
@@ -93,7 +93,7 @@ class BACnetCoordinator(BaseProtocolCoordinator):
             )
             return None
             
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
             _LOGGER.error(
                 "Error reading entity %s: %s",
                 entity_config.get("name"),
@@ -159,7 +159,7 @@ class BACnetCoordinator(BaseProtocolCoordinator):
             _LOGGER.error("Invalid address for entity %s: %s", entity_config.get("name"), err)
             return False
 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
             _LOGGER.error("Write error for entity %s: %s", entity_config.get("name"), err)
             import traceback
             _LOGGER.error(traceback.format_exc())
@@ -337,7 +337,7 @@ class BACnetCoordinator(BaseProtocolCoordinator):
                     failed_count += 1
                     consecutive_failures += 1
 
-                except Exception as err:
+                except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
                     _LOGGER.error(
                         "Error reading entity %s: %s",
                         entity.get("name"),
@@ -375,7 +375,7 @@ class BACnetCoordinator(BaseProtocolCoordinator):
             else:
                 _LOGGER.warning("[BACnet] Connection failed")
                 return False
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
             _LOGGER.error("[BACnet] Connection error: %s", err)
             return False
     
@@ -561,7 +561,7 @@ class BACnetCoordinator(BaseProtocolCoordinator):
             _LOGGER.error("Invalid address for entity %s: %s", entity_name, err)
             return False
         
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError, RuntimeError) as err:
             _LOGGER.error("Write error for entity %s: %s", entity_name, err)
             return False
     

--- a/custom_components/protocol_wizard/protocols/base.py
+++ b/custom_components/protocol_wizard/protocols/base.py
@@ -126,7 +126,7 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
             try:
                 numeric = float(value)
             except (TypeError, ValueError):
-                pass
+                _LOGGER.debug("Value %r is not numeric, skipping numeric format helpers", value)
     
             if numeric is not None:
                 total = int(numeric)
@@ -150,7 +150,7 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
     
             return result
     
-        except Exception as err:
+        except (ValueError, TypeError, KeyError) as err:
             _LOGGER.debug(
                 "Format error for entity '%s': %s",
                 entity_config.get("name"),
@@ -209,6 +209,6 @@ class BaseProtocolCoordinator(DataUpdateCoordinator, ABC):
         
         try:
             return await self.client.connect()
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("[%s] Failed to connect: %s", self.protocol_name, err)
             return False

--- a/custom_components/protocol_wizard/protocols/modbus/client.py
+++ b/custom_components/protocol_wizard/protocols/modbus/client.py
@@ -59,7 +59,7 @@ class ModbusClient(BaseProtocolClient):
                 await self._client.connect()
             self._conn_state["failed"] = False
             return self._client.connected
-        except Exception as err:
+        except (ModbusIOException, OSError, ConnectionError) as err:
             _LOGGER.error("Modbus connection failed: %s", err)
             self._conn_state["failed"] = True
             return False
@@ -70,7 +70,7 @@ class ModbusClient(BaseProtocolClient):
             if self._client.connected:
                 self._client.close()
             self._conn_state["failed"] = False
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001
             _LOGGER.debug("Error closing Modbus client: %s", err)
 
     async def reconnect(self) -> bool:
@@ -99,8 +99,8 @@ class ModbusClient(BaseProtocolClient):
                 # Force close regardless of state
                 try:
                     self._client.close()
-                except Exception:
-                    pass
+                except Exception:  # noqa: BLE001
+                    _LOGGER.debug("Error closing Modbus client during reconnect")
 
                 # Small delay before reconnecting
                 await asyncio.sleep(0.3)
@@ -110,7 +110,7 @@ class ModbusClient(BaseProtocolClient):
                 self._conn_state["failed"] = False
                 _LOGGER.info("Modbus reconnection successful")
                 return self._client.connected
-            except Exception as err:
+            except (ModbusIOException, OSError, ConnectionError) as err:
                 _LOGGER.error("Modbus reconnection failed: %s", err)
                 self._conn_state["failed"] = True
                 return False
@@ -163,7 +163,7 @@ class ModbusClient(BaseProtocolClient):
                           address, self.slave_id, err)
             self._conn_state["failed"] = True  # Mark shared state for reconnection
             raise  # Re-raise so coordinator can handle
-        except Exception as err:
+        except (OSError, ConnectionError) as err:
             _LOGGER.error("Modbus read error at %s (slave %d): %s",
                          address, self.slave_id, err)
             self._conn_state["failed"] = True
@@ -217,7 +217,7 @@ class ModbusClient(BaseProtocolClient):
                           address, self.slave_id, err)
             self._conn_state["failed"] = True
             return False
-        except Exception as err:
+        except (OSError, ConnectionError) as err:
             _LOGGER.error("Modbus write failed at %s (slave %d): %s",
                          address, self.slave_id, err)
             self._conn_state["failed"] = True

--- a/custom_components/protocol_wizard/protocols/modbus/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/modbus/coordinator.py
@@ -12,6 +12,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from pymodbus.client.mixin import ModbusClientMixin
+from pymodbus.exceptions import ModbusIOException
 
 from ...const import CONF_REGISTERS, CONF_SLAVES
 from .. import ProtocolRegistry
@@ -70,7 +71,7 @@ class ModbusCoordinator(BaseProtocolCoordinator):
         # Need to connect
         try:
             return await self.client.connect()
-        except Exception as err:
+        except (ModbusIOException, OSError, ConnectionError) as err:
             _LOGGER.error("[Modbus] Failed to connect: %s", err)
             return False
 
@@ -218,7 +219,8 @@ class ModbusCoordinator(BaseProtocolCoordinator):
                 result = await method(address=address, count=count, device_id=self.client.slave_id)
                 if not result.isError():
                     return name, result
-            except Exception:
+            except (ModbusIOException, OSError, ConnectionError):
+                _LOGGER.debug("Auto-detect: type %s failed at address %d", name, address)
                 continue
 
         _LOGGER.warning("Auto-detect failed at address %d", address)
@@ -240,7 +242,7 @@ class ModbusCoordinator(BaseProtocolCoordinator):
 
         try:
             return await method(address=address, count=count, device_id=self.client.slave_id)
-        except Exception as err:
+        except (ModbusIOException, OSError, ConnectionError) as err:
             _LOGGER.error("Direct read failed for type %s: %s", reg_type, err)
             return None
     
@@ -293,13 +295,12 @@ class ModbusCoordinator(BaseProtocolCoordinator):
                 decoded = decoded * scale + offset
 
                 # Preserve integer type for integer data types when result is whole number
-                if data_type in ("uint16", "int16", "uint32", "int32", "uint64", "int64"):
-                    if isinstance(decoded, float) and decoded.is_integer():
-                        decoded = int(decoded)
+                if data_type in ("uint16", "int16", "uint32", "int32", "uint64", "int64") and isinstance(decoded, float) and decoded.is_integer():
+                    decoded = int(decoded)
 
             return decoded
 
-        except Exception as err:
+        except (ValueError, TypeError) as err:
             _LOGGER.error(
                 "Error decoding register '%s' at address %s: %s",
                 entity_config.get("name"), entity_config.get("address"), err
@@ -348,7 +349,7 @@ class ModbusCoordinator(BaseProtocolCoordinator):
             if scale != 0:
                 try:
                     value = (value - offset) / scale
-                except Exception as err:
+                except (ValueError, TypeError) as err:
                     _LOGGER.error("Scale/offset failed for value %s: %s", original_value, err)
                     return None
         
@@ -356,14 +357,14 @@ class ModbusCoordinator(BaseProtocolCoordinator):
             if data_type in ("uint16", "int16"):
                 try:
                     value = round(float(value))
-                except Exception:
+                except (ValueError, TypeError):
                     _LOGGER.error("Failed to convert to int for %s: %s", data_type, original_value)
                     return None
                 if data_type == "int16" and value < 0:
                     value += 65536
                 value = max(0, min(65535, value))
                 return [value]
-        except Exception as err:
+        except (ValueError, TypeError) as err:
             _LOGGER.error("Encoding error %s (%s): %s", value, data_type, err)
             return None    
         # Multi-register types
@@ -387,7 +388,7 @@ class ModbusCoordinator(BaseProtocolCoordinator):
                 data_type=target_type,
                 word_order=0 if word_order == "big" else 1,
             )
-        except Exception as err:
+        except (ValueError, TypeError) as err:
             _LOGGER.error("pymodbus convert_to_registers failed for %s (%s): %s", original_value, data_type, err)
             return None
     # ----------------------------------------------------------------------------
@@ -395,8 +396,6 @@ class ModbusCoordinator(BaseProtocolCoordinator):
     #------------------------------------------------------------------------------
     
     async def async_read_entity(self, address: str, entity_config: dict, **kwargs) -> Any | None:
-        from pymodbus.exceptions import ModbusIOException
-
         addr = int(address)
         size = kwargs.get("size") or TYPE_SIZES.get(entity_config.get("data_type", "uint16").lower(), 1)
         reg_type = kwargs.get("register_type") or entity_config.get("register_type", "holding")

--- a/custom_components/protocol_wizard/protocols/mqtt/client.py
+++ b/custom_components/protocol_wizard/protocols/mqtt/client.py
@@ -64,7 +64,7 @@ class MQTTClient(BaseProtocolClient):
                     try:
                         self._client.subscribe(topic, qos=0)
      #                   _LOGGER.debug("Resubscribed to %s", topic)
-                    except Exception as err:
+                    except (OSError, ConnectionError, TimeoutError) as err:
                         _LOGGER.error("Failed to resubscribe to %s: %s", topic, err)
         else:
             _LOGGER.error("MQTT connection failed with code %s", rc)
@@ -141,7 +141,7 @@ class MQTTClient(BaseProtocolClient):
             _LOGGER.error("MQTT connection timeout to %s:%s", self.broker, self.port)
             return False
             
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("MQTT connection failed: %s", err)
             self._connected = False
             return False
@@ -156,8 +156,8 @@ class MQTTClient(BaseProtocolClient):
                 
                 await asyncio.get_event_loop().run_in_executor(None, do_disconnect)
                 _LOGGER.info("MQTT disconnected and loop stopped")
-            except Exception as err:
-                _LOGGER.error("Error during MQTT disconnect: %s", err)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Error during MQTT disconnect: %s", err)
             
             self._connected = False
 
@@ -197,7 +197,7 @@ class MQTTClient(BaseProtocolClient):
                 _LOGGER.error("Failed to subscribe to %s", topic)
                 return False
                 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("MQTT subscribe error: %s", err)
             return False
 
@@ -402,7 +402,7 @@ class MQTTClient(BaseProtocolClient):
             
             return success
             
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("MQTT publish error: %s", err)
             return False
 

--- a/custom_components/protocol_wizard/protocols/mqtt/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/mqtt/coordinator.py
@@ -93,7 +93,7 @@ class MQTTCoordinator(BaseProtocolCoordinator):
                     # Store raw for debugging
                     new_data[f"{key}_raw"] = payload
                 
-            except Exception as err:
+            except (ValueError, TypeError, KeyError) as err:
                 _LOGGER.warning(
                     "Failed to read MQTT topic %s: %s",
                     topic,
@@ -203,7 +203,7 @@ class MQTTCoordinator(BaseProtocolCoordinator):
                 return None
             return raw_value
             
-        except Exception as err:
+        except (json.JSONDecodeError, ValueError, TypeError) as err:
             _LOGGER.warning("Failed to decode value: %s", err)
             # If numeric entity, return None on error (shows as unavailable)
             # Otherwise return None to avoid invalid state
@@ -333,7 +333,7 @@ class MQTTCoordinator(BaseProtocolCoordinator):
             # Single topic - decode normally
             return self._decode_value(payload, entity_config)
             
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("Failed to read MQTT topic %s: %s", address, err)
             return None
 
@@ -383,7 +383,7 @@ class MQTTCoordinator(BaseProtocolCoordinator):
                 retain=retain,
             )
             
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("Failed to write to MQTT topic %s: %s", address, err)
             return False
 
@@ -394,6 +394,6 @@ class MQTTCoordinator(BaseProtocolCoordinator):
         
         try:
             return await self.client.connect()
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("Failed to connect to MQTT broker: %s", err)
             return False

--- a/custom_components/protocol_wizard/protocols/snmp/client.py
+++ b/custom_components/protocol_wizard/protocols/snmp/client.py
@@ -75,7 +75,7 @@ class SNMPClient(BaseProtocolClient):
             value = await self.read("1.3.6.1.2.1.1.1.0")  # sysDescr
             self._connected = value is not None
             return self._connected
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("SNMP connection test failed for %s:%s: %s", self.host, self.port, err)
             self._connected = False
             return False
@@ -85,7 +85,7 @@ class SNMPClient(BaseProtocolClient):
         if self._engine:
             try:
                 self._engine.close_dispatcher()
-            except Exception as err:
+            except Exception as err:  # noqa: BLE001
                 _LOGGER.debug("Error closing SNMP dispatcher: %s", err)
             finally:
                 self._engine = None
@@ -119,7 +119,7 @@ class SNMPClient(BaseProtocolClient):
                 return var_binds[0][1]  # Return just the value
             return None
 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("SNMP read failed for OID %s: %s", address, err)
             return None
             
@@ -177,7 +177,7 @@ class SNMPClient(BaseProtocolClient):
                     pretty_value = value.prettyPrint() if hasattr(value, 'prettyPrint') else str(value)
                     results.append((pretty_oid, pretty_value))
     
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("SNMP walk failed for %s: %s", base_oid, err)
     
         return results
@@ -208,7 +208,7 @@ class SNMPClient(BaseProtocolClient):
 
             return True
 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("SNMP write failed for OID %s: %s", address, err)
             return False
 

--- a/custom_components/protocol_wizard/protocols/snmp/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/snmp/coordinator.py
@@ -114,7 +114,7 @@ class SNMPCoordinator(BaseProtocolCoordinator):
                         formatted = self._format_value(decoded, entity)
                         new_data[key] = formatted
 
-                except Exception as err:
+                except (OSError, ConnectionError, TimeoutError) as err:
                     _LOGGER.error("Error processing %s %s: %s", read_mode, oid, err)
                     failed_count += 1
                     consecutive_failures += 1
@@ -160,7 +160,7 @@ class SNMPCoordinator(BaseProtocolCoordinator):
 
             return decoded
 
-        except Exception as err:
+        except (ValueError, TypeError) as err:
             _LOGGER.error("Decode error for OID %s: %s", entity_config.get("address"), err)
             return None
 
@@ -182,7 +182,7 @@ class SNMPCoordinator(BaseProtocolCoordinator):
             # pysnmp handles type mapping — just return clean Python value
             return value
 
-        except Exception as err:
+        except (ValueError, TypeError) as err:
             _LOGGER.error("Encode error for %s: %s", entity_config.get("name"), err)
             return None
 
@@ -214,7 +214,7 @@ class SNMPCoordinator(BaseProtocolCoordinator):
 
                 return self._decode_value(raw_value, entity_config)
 
-            except Exception as err:
+            except (OSError, ConnectionError, TimeoutError) as err:
                 _LOGGER.error("Service read failed for OID %s: %s", address, err)
                 return None
 
@@ -242,6 +242,6 @@ class SNMPCoordinator(BaseProtocolCoordinator):
 
             return success
 
-        except Exception as err:
+        except (OSError, ConnectionError, TimeoutError) as err:
             _LOGGER.error("Write failed for OID %s: %s", address, err)
             return False

--- a/custom_components/protocol_wizard/template_utils.py
+++ b/custom_components/protocol_wizard/template_utils.py
@@ -77,7 +77,7 @@ def ensure_user_template_dirs(hass: HomeAssistant) -> None:
         if not readme_path.exists():
             readme_path.write_text(_get_readme_content(), encoding='utf-8')
             _LOGGER.info("Created user templates directory: %s", base_path)
-    except Exception as err:
+    except OSError as err:
         _LOGGER.warning("Failed to create user template directories: %s", err)
 
 
@@ -142,7 +142,7 @@ async def get_available_templates(
                     "source": "builtin",
                     "path": str(builtin_dir / f"{name}.json"),
                 }
-        except Exception as err:
+        except OSError as err:
             _LOGGER.warning("Failed to list built-in templates for %s: %s", protocol, err)
     
     # Load user templates
@@ -164,7 +164,7 @@ async def get_available_templates(
                     "source": "user",
                     "path": str(user_dir / f"{name}.json"),
                 }
-        except Exception as err:
+        except OSError as err:
             _LOGGER.warning("Failed to list user templates for %s: %s", protocol, err)
     
     return templates
@@ -219,7 +219,7 @@ async def load_template(
     except json.JSONDecodeError as err:
         _LOGGER.error("Failed to parse template %s: %s", template_id, err)
         return None
-    except Exception as err:
+    except OSError as err:
         _LOGGER.error("Failed to load template %s: %s", template_id, err)
         return None
 
@@ -296,7 +296,7 @@ async def save_template(
         relative_path = template_path.relative_to(Path(hass.config.config_dir))
         _LOGGER.info("Saved template to %s", template_path)
         return True, f"Template saved to {relative_path}"
-    except Exception as err:
+    except OSError as err:
         _LOGGER.error("Failed to save template: %s", err)
         return False, f"Failed to save: {err}"
 
@@ -332,7 +332,7 @@ async def delete_template(
         await hass.async_add_executor_job(template_path.unlink)
         _LOGGER.info("Deleted template: %s", template_path)
         return True, "Template deleted"
-    except Exception as err:
+    except OSError as err:
         _LOGGER.error("Failed to delete template: %s", err)
         return False, f"Failed to delete: {err}"
 


### PR DESCRIPTION
- Replace broad `except Exception` with specific types throughout:
  - Network ops: (OSError, ConnectionError, TimeoutError)
  - Data conversion: (ValueError, TypeError)
  - JSON parsing: (json.JSONDecodeError, ValueError)
  - Modbus: (ModbusIOException, OSError, ConnectionError)
  - BACnet: (OSError, ConnectionError, TimeoutError, RuntimeError)
- Cleanup/disconnect handlers: add noqa: BLE001 where catching everything is intentional
- Replace _LOGGER.error(exc_info=True) with _LOGGER.exception() (G201)
- Remove redundant err in exception() calls (TRY401)
- Replace raise Exception() with raise ConnectionError() (TRY002)
- Replace try-except-pass with debug logging (S110)
- Add debug logging to try-except-continue (S112)
- Combine nested if into single statement (SIM102)
- Add ClassVar annotation to mutable class default (RUF012)

https://claude.ai/code/session_0141XkQRjcng4RKLD4Yv5FAr