### PR TITLE
Fix test to use ValueError instead of bare Exception

### DIFF
--- a/tests/test_modbus_coordinator.py
+++ b/tests/test_modbus_coordinator.py
@@ -109,7 +109,7 @@ class TestModbusDecodeValue:
 
     def test_decode_exception_returns_none(self):
         coord = _make_coordinator()
-        coord.client.raw_client.convert_from_registers.side_effect = Exception("fail")
+        coord.client.raw_client.convert_from_registers.side_effect = ValueError("fail")
         result = coord._decode_value([42], {"data_type": "uint16"})
         assert result is None
 


### PR DESCRIPTION
The _decode_value method now catches (ValueError, TypeError) instead of Exception, so the test must raise a matching exception type.

https://claude.ai/code/session_0141XkQRjcng4RKLD4Yv5FAr