### PR TITLE
Fix: catch OSError/ConnectionError in Modbus service read path

### DIFF
--- a/custom_components/protocol_wizard/protocols/modbus/coordinator.py
+++ b/custom_components/protocol_wizard/protocols/modbus/coordinator.py
@@ -425,10 +425,10 @@ class ModbusCoordinator(BaseProtocolCoordinator):
                                 values = test_values
                                 detected_type = test_type
                                 break
-                        except ModbusIOException:
+                        except (ModbusIOException, OSError, ConnectionError):
                             continue  # Try next type
 
-            except ModbusIOException as err:
+            except (ModbusIOException, OSError, ConnectionError) as err:
                 _LOGGER.warning("[Modbus] I/O error reading address %s: %s - will attempt reconnect on next request", address, err)
                 # Connection will be recovered on next _async_connect call
                 return None


### PR DESCRIPTION
The async_read_entity() method (service-call path) only caught ModbusIOException but client.read() can also raise OSError and ConnectionError on network failures. This caused unhandled exceptions when using the read_register service with unreachable devices.

The bulk-read path (_auto_detect_type, _direct_read) already handled these correctly — only the service path was missed.

https://claude.ai/code/session_0141XkQRjcng4RKLD4Yv5FAr